### PR TITLE
PR: Add the capability to add comment to frame

### DIFF
--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -20,7 +20,8 @@ from PyQt5.QtWidgets import (QApplication, QWidget, QGridLayout, QLabel,
                              QTableView, QItemDelegate, QPushButton,
                              QStyleOptionButton, QStyle, QStyledItemDelegate,
                              QStyleOptionToolButton, QStyleOptionViewItem,
-                             QHeaderView, QMessageBox, QSizePolicy)
+                             QHeaderView, QMessageBox, QSizePolicy,
+                             QTextEdit)
 
 # ---- Local imports
 
@@ -61,11 +62,17 @@ class QWatson(QWidget):
         self.setup_toolbar()
         self.setup_project_cbox()
 
+        self.msg_textedit = QTextEdit()
+        self.msg_textedit.setMaximumHeight(50)
+        self.msg_textedit.setSizePolicy(
+                QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed))
+
         layout = QGridLayout(self)
         layout.addWidget(QLabel('Project :'), 0, 0)
         layout.addWidget(self.project_cbox, 0, 1)
         layout.addWidget(self.toolbar, 0, 2)
-        layout.addWidget(timebar, 1, 0, 1, 3)
+        layout.addWidget(self.msg_textedit, 1, 0, 1, 3)
+        layout.addWidget(timebar, 2, 0, 1, 3)
 
         layout.setColumnStretch(1, 100)
         layout.setRowStretch(1, 100)
@@ -169,6 +176,7 @@ class QWatson(QWidget):
             self.model.beginInsertRows(QModelIndex(),
                                        len(self.client.frames),
                                        len(self.client.frames))
+            self.client._current['message'] = self.msg_textedit.toPlainText()
             self.client.stop()
             self.client.save()
             self.model.endInsertRows()
@@ -240,7 +248,7 @@ class WatsonTableView(QTableView):
 
 class WatsonTableModel(QAbstractTableModel):
 
-    HEADER = ['', 'start', 'end', 'duration', 'project', 'id']
+    HEADER = ['', 'start', 'end', 'duration', 'project', 'comment', 'id']
     sig_btn_delrow_clicked = QSignal(QModelIndex)
 
     def __init__(self, client, checked=False):
@@ -269,6 +277,9 @@ class WatsonTableModel(QAbstractTableModel):
             elif index.column() == 4:
                 return str(self.frames[index.row()][2])
             elif index.column() == 5:
+                msg = self.frames[index.row()].message
+                return '' if msg is None else msg
+            elif index.column() == 6:
                 return self.frames[index.row()].id
             else:
                 return ''

--- a/qwatson/watson/frames.py
+++ b/qwatson/watson/frames.py
@@ -13,11 +13,12 @@ import arrow
 
 from collections import namedtuple
 
-HEADERS = ('start', 'stop', 'project', 'id', 'tags', 'updated_at')
+FIELDS = ('start', 'stop', 'project', 'id', 'tags', 'updated_at', 'message')
 
 
-class Frame(namedtuple('Frame', HEADERS)):
-    def __new__(cls, start, stop, project, id, tags=None, updated_at=None,):
+class Frame(namedtuple('Frame', FIELDS)):
+    def __new__(cls, start, stop, project, id, tags=None, updated_at=None,
+                message=None):
         try:
             if not isinstance(start, arrow.Arrow):
                 start = arrow.get(start)
@@ -40,7 +41,7 @@ class Frame(namedtuple('Frame', HEADERS)):
             tags = []
 
         return super(Frame, cls).__new__(
-            cls, start, stop, project, id, tags, updated_at
+            cls, start, stop, project, id, tags, updated_at, message
         )
 
     def dump(self):
@@ -48,7 +49,8 @@ class Frame(namedtuple('Frame', HEADERS)):
         stop = self.stop.to('utc').timestamp
         updated_at = self.updated_at.timestamp
 
-        return (start, stop, self.project, self.id, self.tags, updated_at)
+        return (start, stop, self.project, self.id, self.tags, updated_at,
+                self.message)
 
     @property
     def day(self):
@@ -91,7 +93,7 @@ class Frames(object):
         return len(self._rows)
 
     def __getitem__(self, key):
-        if key in HEADERS:
+        if key in FIELDS:
             return tuple(self._get_col(key))
         elif isinstance(key, int):
             return self._rows[key]
@@ -132,7 +134,7 @@ class Frames(object):
             raise KeyError("Frame with id {} not found.".format(id))
 
     def _get_col(self, col):
-        index = HEADERS.index(col)
+        index = FIELDS.index(col)
         for row in self._rows:
             yield row[index]
 
@@ -143,11 +145,11 @@ class Frames(object):
         return frame
 
     def new_frame(self, project, start, stop, tags=None, id=None,
-                  updated_at=None):
+                  updated_at=None, message=None):
         if not id:
             id = uuid.uuid4().hex
         return Frame(start, stop, project, id, tags=tags,
-                     updated_at=updated_at)
+                     updated_at=updated_at, message=message)
 
     def dump(self):
         return tuple(frame.dump() for frame in self._rows)

--- a/qwatson/watson/watson.py
+++ b/qwatson/watson/watson.py
@@ -154,6 +154,7 @@ class Watson(object):
                         'project': self.current['project'],
                         'start': self._format_date(self.current['start']),
                         'tags': self.current['tags'],
+                        'message': self.current.get('message'),
                     }
                 else:
                     current = {}
@@ -214,7 +215,8 @@ class Watson(object):
         self._current = {
             'project': value['project'],
             'start': start,
-            'tags': value.get('tags') or []
+            'tags': value.get('tags') or [],
+            'message': value.get('message'),
         }
 
         if self._old_state is None:
@@ -268,7 +270,8 @@ class Watson(object):
 
         old = self.current
         frame = self.frames.add(
-            old['project'], old['start'], arrow.now(), tags=old['tags']
+            old['project'], old['start'], arrow.now(), tags=old['tags'],
+            message=old.get('message')
         )
         self.current = None
 


### PR DESCRIPTION
While waiting for https://github.com/TailorDev/Watson/pull/119 to be merged, this PR is a quick workaround to provide the functionality to add a `message` to Watson Frame from the GUI and to display it in the TableView.

The same structure as the one proposed in https://github.com/TailorDev/Watson/pull/119 was preserved, so it should be easy to revert to the official version of `Watson` once https://github.com/TailorDev/Watson/pull/119 is merged on the master branch of the main `Watson` repo.

![qwatson_message_edit](https://user-images.githubusercontent.com/10170372/40946508-e3d06c34-682b-11e8-9176-4d59288134e1.gif)