### PR TITLE
PR: Add the possibility to change the project of a frame from the tableview

### DIFF
--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -226,6 +226,7 @@ class WatsonTableView(QTableView):
 
         self.setModel(model)
         self.setItemDelegateForColumn(0, ToolButtonDelegate(self))
+        self.setItemDelegateForColumn(4, ComboBoxDelegate(self))
         self.setItemDelegateForColumn(5, LineEditDelegate(self))
 
         self.setColumnWidth(0, icons.get_iconsize('small').width() + 8)
@@ -277,7 +278,7 @@ class WatsonTableModel(QAbstractTableModel):
                                  self.frames[index.row()][0]).total_seconds()
                 return strftime("%H:%M:%S", gmtime(total_seconds))
             elif index.column() == 4:
-                return str(self.frames[index.row()][2])
+                return str(self.frames[index.row()].project)
             elif index.column() == 5:
                 msg = self.frames[index.row()].message
                 return '' if msg is None else msg
@@ -304,7 +305,7 @@ class WatsonTableModel(QAbstractTableModel):
 
     def flags(self, index):
         """Qt method override."""
-        if index.column() == 5:
+        if index.column() in [4, 5]:
             return Qt.ItemIsEnabled | Qt.ItemIsEditable
         else:
             return Qt.ItemIsEnabled
@@ -396,7 +397,7 @@ class LineEditDelegate(QStyledItemDelegate):
         QStyledItemDelegate.__init__(self, parent)
 
     def createEditor(self, parent, option, index):
-        """Qt method override to prevent the creation of an editor."""
+        """Qt method override."""
         return QLineEdit(parent)
 
     def setEditorData(self, editor, index):
@@ -405,7 +406,9 @@ class LineEditDelegate(QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):
         """Qt method override."""
-        model.editMessage(index, editor.text())
+        if editor.text() != index.model().data(index):
+            model.editMessage(index, editor.text())
+
 
 class ComboBoxDelegate(QStyledItemDelegate):
     def __init__(self, parent):

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -11,19 +11,18 @@
 import sys
 import platform
 from time import strftime, gmtime
+import dateutil
 
 # ---- Third parties imports
 
 import arrow
 from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtCore import (Qt, QAbstractTableModel, QVariant, QRect, QPoint,
-                          QSize,QEvent, QModelIndex)
+                          QEvent, QModelIndex)
 from PyQt5.QtWidgets import (QApplication, QWidget, QGridLayout, QLabel,
-                             QTableView, QItemDelegate, QPushButton,
-                             QStyleOptionButton, QStyle, QStyledItemDelegate,
-                             QStyleOptionToolButton, QStyleOptionViewItem,
-                             QHeaderView, QMessageBox, QSizePolicy,
-                             QTextEdit, QLineEdit)
+                             QTableView, QStyle, QStyledItemDelegate,
+                             QStyleOptionToolButton, QHeaderView, QMessageBox,
+                             QSizePolicy, QTextEdit, QLineEdit, QComboBox)
 
 # ---- Local imports
 


### PR DESCRIPTION
Add the possibility to change the project of a frame directly from the table with a combobox delegate that holds a list of all the existing projects that are stored in `Frames`.

![qwatson_change_project](https://user-images.githubusercontent.com/10170372/40948273-846fe8b4-6835-11e8-8712-42b51e8e1f27.gif)
