### PR TITLE
PR: Add sort and filtering capability to the WatsonTableView

### DIFF
--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -284,7 +284,7 @@ class WatsonTableView(QTableView):
 
     def del_model_row(self, index):
         """Delete a row from the model."""
-        frame_id = self.model().frames[index.row()].id
+        frame_id = self.model().get_frameid_from_index(index)
         ans = QMessageBox.question(
             self, 'Delete frame', "Do you want to delete frame %s?" % frame_id,
             defaultButton=QMessageBox.No)
@@ -371,6 +371,10 @@ class WatsonTableModel(QAbstractTableModel):
     @property
     def projects(self):
         return self.client.projects
+
+    def get_frameid_from_index(self, index):
+        """Return the frame id from a table index."""
+        return self.frames[index.row()].id
 
     def get_start_qdatetime_range(self, index):
         """

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -368,6 +368,9 @@ class WatsonTableModel(QAbstractTableModel):
 
     # ---- Watson handlers
 
+    @property
+    def projects(self):
+        return self.client.projects
 
     def get_start_qdatetime_range(self, index):
         """
@@ -505,7 +508,7 @@ class ComboBoxDelegate(QStyledItemDelegate):
 
     def setEditorData(self, editor, index):
         """Qt method override."""
-        editor.addItems(index.model().client.projects)
+        editor.addItems(index.model().projects)
         editor.setCurrentIndex(editor.findText(index.model().data(index)))
 
     def setModelData(self, editor, model, index):

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -341,7 +341,7 @@ class WatsonTableModel(QAbstractTableModel):
             elif index.column() == self.COLUMNS['id']:
                 return self.frames[index.row()].id
             elif index.column() == self.COLUMNS['icons']:
-                return "Delete corresponding frame"
+                return "Delete frame"
         elif role == Qt.TextAlignmentRole:
             if index.column() == self.COLUMNS['comment']:
                 return Qt.AlignLeft | Qt.AlignVCenter

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -491,7 +491,7 @@ class LineEditDelegate(QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):
         """Qt method override."""
-        if editor.text() != index.model().data(index):
+        if editor.text() != model.data(index):
             model.editFrame(index, message=editor.text())
 
 
@@ -510,7 +510,7 @@ class ComboBoxDelegate(QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):
         """Qt method override."""
-        if editor.currentText() != index.model().data(index):
+        if editor.currentText() != model.data(index):
             model.editFrame(index, project=editor.currentText())
 
 
@@ -532,7 +532,7 @@ class DateTimeDelegate(QStyledItemDelegate):
     def setModelData(self, editor, model, index):
         """Qt method override."""
         date_time = editor.dateTime().toString("yyyy-MM-dd hh:mm")
-        if date_time != index.model().data(index):
+        if date_time != model.data(index):
             model.editDateTime(index, date_time+':00')
 
 


### PR DESCRIPTION
Add sort and filtering capability in the `WatsonTableView` by using a proxy model for our `WatsonTableModel`, which is derived from `QAbstractTableModel`.

The proxy model is derived from `QSortFilterProxyModel`.