### PR TITLE
PR: Add support for tags

### DIFF
--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -181,15 +181,18 @@ class QWatson(QWidget):
         else:
             self.elap_timer.stop()
             self.stop_watson(message=self.msg_textedit.toPlainText(),
-                             project=self.project_manager.current_project)
+                             project=self.project_manager.current_project,
+                             tags=self.tag_manager.tags)
         self.project_manager.setEnabled(not self.btn_startstop.value())
 
-    def stop_watson(self, message=None, project=None):
+    def stop_watson(self, message=None, project=None, tags=None):
         """Stop Watson and update the table model."""
         if message is not None:
             self.client._current['message'] = message
         if project is not None:
             self.client._current['project'] = project
+        if tags is not None:
+            self.client._current['tags'] = tags
 
         self.model.beginInsertRows(
             QModelIndex(), len(self.client.frames), len(self.client.frames))

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -25,8 +25,7 @@ from qwatson.utils import icons
 from qwatson.widgets.clock import ElapsedTimeLCDNumber
 from qwatson.widgets.dates import DateRangeNavigator
 from qwatson.widgets.tableviews import WatsonDailyTableWidget
-from qwatson.widgets.toolbar import (ToolBarWidget, OnOffToolButton,
-                                     QToolButtonSmall)
+from qwatson.widgets.toolbar import OnOffToolButton, QToolButtonSmall
 from qwatson import __namever__
 from qwatson.models.tablemodels import WatsonTableModel
 from qwatson.widgets.layout import VSep

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -30,7 +30,7 @@ from qwatson.widgets.toolbar import (ToolBarWidget, OnOffToolButton,
 from qwatson import __namever__
 from qwatson.models.tablemodels import WatsonTableModel
 from qwatson.widgets.layout import VSep
-from qwatson.widgets.projects_and_tags import ProjectManager
+from qwatson.widgets.projects_and_tags import ProjectManager, TagManager
 
 
 class QWatson(QWidget):
@@ -77,6 +77,10 @@ class QWatson(QWidget):
         self.msg_textedit.setSizePolicy(
                 QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed))
 
+        self.tag_manager = TagManager()
+        if len(self.client.frames) > 0:
+            self.tag_manager.set_tags(self.client.frames[-1].tags)
+
         # ---- Setup the layout
 
         project_toolbar = QGridLayout()
@@ -89,7 +93,8 @@ class QWatson(QWidget):
         layout = QGridLayout(self)
         layout.addLayout(project_toolbar, 0, 0)
         layout.addWidget(self.msg_textedit, 1, 0)
-        layout.addWidget(timebar, 2, 0)
+        layout.addWidget(self.tag_manager, 2, 0)
+        layout.addWidget(timebar, 3, 0)
 
         layout.setRowStretch(1, 100)
 

--- a/qwatson/models/delegates.py
+++ b/qwatson/models/delegates.py
@@ -17,6 +17,30 @@ from PyQt5.QtWidgets import (
 
 from qwatson.utils.dates import qdatetime_from_str
 from qwatson.utils import icons
+from qwatson.utils.strformating import list_to_str
+from qwatson.widgets.projects_and_tags import TagLineEdit
+
+
+class TagEditDelegate(QStyledItemDelegate):
+    """
+    A delegate that allow to edit the tags of a frame and
+    force an update of the Watson data via the model.
+    """
+    def __init__(self, parent):
+        QStyledItemDelegate.__init__(self, parent)
+
+    def createEditor(self, parent, option, index):
+        """Qt method override."""
+        return TagLineEdit(parent)
+
+    def setEditorData(self, editor, index):
+        """Qt method override."""
+        editor.set_tags(index.model().get_tags_from_index(index))
+
+    def setModelData(self, editor, model, index):
+        """Qt method override."""
+        if list_to_str(editor.tags) != model.data(index):
+            model.editFrame(index, tags=editor.tags)
 
 
 class ToolButtonDelegate(QStyledItemDelegate):

--- a/qwatson/models/tablemodels.py
+++ b/qwatson/models/tablemodels.py
@@ -179,17 +179,17 @@ class WatsonTableModel(QAbstractTableModel):
         datetime_format = '{} {}'.format('YYYY-MM-DD', 'HH:mm:ss')
         frame = self.frames[index.row()]
 
-        start = start or frame.start.format(datetime_format)
+        start = frame.start.format(datetime_format) if start is None else start
         start = arrow.get(start, datetime_format).replace(
             tzinfo=dateutil.tz.tzlocal()).to('utc')
 
-        stop = stop or frame.stop.format(datetime_format)
+        stop = frame.stop.format(datetime_format) if stop is None else stop
         stop = arrow.get(stop, datetime_format).replace(
             tzinfo=dateutil.tz.tzlocal()).to('utc')
 
-        project = project or frame.project
-        message = message or frame.message
-        tags = tags or frame.tags
+        project = frame.project if project is None else project
+        message = frame.message if message is None else message
+        tags = frame.tags if tags is None else tags
         updated_at = arrow.utcnow().format(datetime_format)
 
         self.frames[frame.id] = [

--- a/qwatson/models/tablemodels.py
+++ b/qwatson/models/tablemodels.py
@@ -22,15 +22,17 @@ from PyQt5.QtCore import (QAbstractTableModel, QModelIndex,
 # ---- Local imports
 
 from qwatson.utils.dates import qdatetime_from_str
+from qwatson.utils.strformating import list_to_str
 
 
 class WatsonTableModel(QAbstractTableModel):
 
-    HEADER = ['start', 'end', 'duration', 'project', 'comment', 'id', '']
+    HEADER = ['start', 'end', 'duration', 'project',
+              'tags', 'comment', 'id', '']
     COLUMNS = {'start': 0, 'end': 1, 'duration': 2, 'project': 3,
-               'comment': 4, 'id': 5, 'icons': 6}
+               'tags': 4, 'comment': 5, 'id': 6, 'icons': 7}
     EDIT_COLUMNS = [COLUMNS['start'], COLUMNS['end'], COLUMNS['project'],
-                    COLUMNS['comment']]
+                    COLUMNS['comment'], COLUMNS['tags']]
     sig_btn_delrow_clicked = QSignal(QModelIndex)
     sig_model_changed = QSignal()
     sig_total_seconds_changed = QSignal(float)
@@ -75,6 +77,8 @@ class WatsonTableModel(QAbstractTableModel):
                 return '' if msg is None else msg
             elif index.column() == self.COLUMNS['id']:
                 return self.frames[index.row()].id
+            elif index.column() == self.COLUMNS['tags']:
+                return list_to_str(self.frames[index.row()].tags)
             else:
                 return ''
         elif role == Qt.ToolTipRole:
@@ -85,8 +89,14 @@ class WatsonTableModel(QAbstractTableModel):
                 return self.frames[index.row()].id
             elif index.column() == self.COLUMNS['icons']:
                 return "Delete frame"
+            elif index.column() == self.COLUMNS['project']:
+                return self.frames[index.row()].project
+            elif index.column() == self.COLUMNS['tags']:
+                return list_to_str(self.frames[index.row()].tags)
         elif role == Qt.TextAlignmentRole:
             if index.column() == self.COLUMNS['comment']:
+                return Qt.AlignLeft | Qt.AlignVCenter
+            if index.column() == self.COLUMNS['tags']:
                 return Qt.AlignLeft | Qt.AlignVCenter
             else:
                 return Qt.AlignCenter
@@ -114,6 +124,10 @@ class WatsonTableModel(QAbstractTableModel):
     @property
     def projects(self):
         return self.client.projects
+
+    def get_tags_from_index(self, index):
+        """Return a list of tags for the frame from a table index."""
+        return self.frames[index.row()].tags
 
     def get_frameid_from_index(self, index):
         """Return the frame id from a table index."""
@@ -157,7 +171,7 @@ class WatsonTableModel(QAbstractTableModel):
         self.endRemoveRows()
 
     def editFrame(self, index, start=None, stop=None, project=None,
-                  message=None):
+                  message=None, tags=None):
         """
         Edit Frame stored at index in the model from the provided
         arguments
@@ -165,20 +179,21 @@ class WatsonTableModel(QAbstractTableModel):
         datetime_format = '{} {}'.format('YYYY-MM-DD', 'HH:mm:ss')
         frame = self.frames[index.row()]
 
-        start = frame.start.format(datetime_format) if start is None else start
+        start = start or frame.start.format(datetime_format)
         start = arrow.get(start, datetime_format).replace(
             tzinfo=dateutil.tz.tzlocal()).to('utc')
 
-        stop = frame.stop.format(datetime_format) if stop is None else stop
+        stop = stop or frame.stop.format(datetime_format)
         stop = arrow.get(stop, datetime_format).replace(
             tzinfo=dateutil.tz.tzlocal()).to('utc')
 
-        project = frame.project if project is None else project
-        message = frame.message if message is None else message
+        project = project or frame.project
+        message = message or frame.message
+        tags = tags or frame.tags
         updated_at = arrow.utcnow().format(datetime_format)
 
         self.frames[frame.id] = [
-            project, start, stop, frame.tags, frame.id, updated_at, message]
+            project, start, stop, tags, frame.id, updated_at, message]
         self.client.save()
         self.dataChanged.emit(index, index)
 
@@ -267,6 +282,11 @@ class WatsonSortFilterProxyModel(QSortFilterProxyModel):
     def projects(self):
         return self.sourceModel().client.projects
 
+    def get_tags_from_index(self, proxy_index):
+        """Return a list of tags for the frame from a table index."""
+        return self.sourceModel().get_tags_from_index(
+                   self.mapToSource(proxy_index))
+
     def get_frameid_from_index(self, proxy_index):
         """Return the frame id from a table index."""
         return self.sourceModel().get_frameid_from_index(
@@ -287,10 +307,11 @@ class WatsonSortFilterProxyModel(QSortFilterProxyModel):
         self.sourceModel().removeRows(self.mapToSource(proxy_index))
 
     def editFrame(self, proxy_index, start=None, stop=None, project=None,
-                  message=None):
+                  message=None, tags=None):
         """Map proxy method to source."""
         self.sourceModel().editFrame(
-            self.mapToSource(proxy_index), start, stop, project, message)
+            self.mapToSource(proxy_index), start=start, stop=stop,
+            project=project, message=message, tags=tags)
 
     def editDateTime(self, proxy_index, date_time):
         """Map proxy method to source."""

--- a/qwatson/utils/strformating.py
+++ b/qwatson/utils/strformating.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+
+def list_to_str(tags, start='[', tail=']', sep='] ['):
+    """Format a list of string to a single string"""
+    if len(tags) == 0 or tags == ['']:
+        return ''
+    else:
+        return start + sep.join(tags) + tail

--- a/qwatson/widgets/projects_and_tags.py
+++ b/qwatson/widgets/projects_and_tags.py
@@ -24,6 +24,27 @@ from qwatson.widgets.toolbar import ToolBarWidget, QToolButtonSmall
 from qwatson.utils import icons
 
 
+class TagManager(QWidget):
+    def __init__(self, tags, parent=None):
+        super(TagManager, self).__init__(parent)
+        self.setup()
+        self.set_tag_list(tags)
+
+    def setup(self):
+        """Setup the widget with the provided arguments."""
+        self.linedit = QLineEdit()
+
+        # ---- Setup the layout
+
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.linedit)
+
+    def set_tag_list(self, tags):
+        """Add a the tag list to the tag line edit."""
+        pass
+
+
 class ProjectManager(QWidget):
     """
     A toolbar composed of a combobox to show the existing projects and

--- a/qwatson/widgets/projects_and_tags.py
+++ b/qwatson/widgets/projects_and_tags.py
@@ -32,24 +32,38 @@ class TagManager(QWidget):
 
     def setup(self):
         """Setup the widget with the provided arguments."""
-        self.linedit = QLineEdit()
-        self.linedit.setPlaceholderText("Tags (comma separated)")
+        self.tag_edit = TagLineEdit()
+        self.tag_edit.setPlaceholderText("Tags (comma separated)")
 
         # ---- Setup the layout
 
         layout = QGridLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.linedit)
+        layout.addWidget(self.tag_edit)
 
     @property
     def tags(self):
-        """Return the list of tags entered in the lineedit."""
-        tags = self.linedit.text().split(',')
+        """Return the list of tags entered in the tag edit line."""
+        return self.tag_edit.tags
+
+    def set_tags(self, tags):
+        """Add a the tag list to the tag edit line."""
+        self.tag_edit.set_tags(tags)
+
+
+class TagLineEdit(QLineEdit):
+    def __init__(self, parent=None):
+        super(TagLineEdit, self).__init__(parent)
+
+    @property
+    def tags(self):
+        """Return the list of tags."""
+        tags = self.text().split(',')
         return sorted(set(tag.strip() for tag in tags))
 
     def set_tags(self, tags):
-        """Add a the tag list to the tag line edit."""
-        self.linedit.setText(', '.join(tags))
+        """Add a the tag list."""
+        self.setText(', '.join(tags))
 
 
 class ProjectManager(QWidget):

--- a/qwatson/widgets/projects_and_tags.py
+++ b/qwatson/widgets/projects_and_tags.py
@@ -25,14 +25,15 @@ from qwatson.utils import icons
 
 
 class TagManager(QWidget):
-    def __init__(self, tags, parent=None):
+    def __init__(self, tags=[], parent=None):
         super(TagManager, self).__init__(parent)
         self.setup()
-        self.set_tag_list(tags)
+        self.set_tags(tags)
 
     def setup(self):
         """Setup the widget with the provided arguments."""
         self.linedit = QLineEdit()
+        self.linedit.setPlaceholderText("Tags (comma separated)")
 
         # ---- Setup the layout
 
@@ -40,9 +41,15 @@ class TagManager(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.linedit)
 
-    def set_tag_list(self, tags):
+    @property
+    def tags(self):
+        """Return the list of tags entered in the lineedit."""
+        tags = self.linedit.text().split(',')
+        return sorted(set(tag.strip() for tag in tags))
+
+    def set_tags(self, tags):
         """Add a the tag list to the tag line edit."""
-        pass
+        self.linedit.setText(', '.join(tags))
 
 
 class ProjectManager(QWidget):

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -26,7 +26,7 @@ from qwatson.utils.dates import arrowspan_to_str, total_seconds_to_hour_min
 from qwatson.models.tablemodels import WatsonSortFilterProxyModel
 from qwatson.models.delegates import (
     ToolButtonDelegate, ComboBoxDelegate, LineEditDelegate, StartDelegate,
-    StopDelegate)
+    StopDelegate, TagEditDelegate)
 
 
 # ---- TableWidget
@@ -74,7 +74,7 @@ class WatsonDailyTableWidget(QFrame):
         self.scene.setSpacing(5)
         self.scene.setContentsMargins(10, 5, 10, 5)
 
-        scrollarea.setMinimumWidth(750)
+        scrollarea.setMinimumWidth(900)
         scrollarea.setMinimumHeight(500)
         scrollarea.setWidget(self.view)
         scrollarea.setWidgetResizable(True)
@@ -213,11 +213,14 @@ class BasicWatsonTableView(QTableView):
             columns['comment'], LineEditDelegate(self))
         self.setItemDelegateForColumn(columns['start'], StartDelegate(self))
         self.setItemDelegateForColumn(columns['end'], StopDelegate(self))
+        self.setItemDelegateForColumn(columns['tags'], TagEditDelegate(self))
 
         # ---- Setup column size
 
-        self.setColumnWidth(
-            columns['icons'], icons.get_iconsize('small').width() + 12)
+        self.setColumnWidth(columns['tags'],
+                            2 * self.horizontalHeader().defaultSectionSize())
+        self.setColumnWidth(columns['icons'],
+                            icons.get_iconsize('small').width() + 12)
         self.horizontalHeader().setSectionResizeMode(QHeaderView.Fixed)
         self.horizontalHeader().setSectionResizeMode(
             columns['comment'], QHeaderView.Stretch)


### PR DESCRIPTION
Fixes #12
- Possible to add tags from the main widget for the current activity
- Tags are shown in the activity overview table
- Possible to edit the tags in the activity overview table

![add_support_for_tags](https://user-images.githubusercontent.com/10170372/41389885-28f708f4-6f61-11e8-8428-817d5b10275e.gif)