### PR TITLE
PR: Show only the first 7 characters of the activity id in the overview table

### DIFF
--- a/qwatson/models/tablemodels.py
+++ b/qwatson/models/tablemodels.py
@@ -76,7 +76,7 @@ class WatsonTableModel(QAbstractTableModel):
                 msg = self.frames[index.row()].message
                 return '' if msg is None else msg
             elif index.column() == self.COLUMNS['id']:
-                return self.frames[index.row()].id
+                return self.frames[index.row()].id[:7]
             elif index.column() == self.COLUMNS['tags']:
                 return list_to_str(self.frames[index.row()].tags)
             else:


### PR DESCRIPTION
There is no need to show the full id in the overview table. 

This PR changes this by only showing the first 7 characters of the id in the overview table. The full id is still shown in the tooltip when hovering over a cell with the mouse.

![image](https://user-images.githubusercontent.com/10170372/41481736-0fc796c8-70a1-11e8-968c-b9ac1144728f.png)
