### PR TITLE
PR: Fix crash when starting and the state file was not empty and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ releases/
 desktop.ini
 frames
 frames.bak
+state
+state.bak
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -54,6 +54,7 @@ class QWatson(QWidget):
 
         self.client = Watson(config_dir=config_dir)
         self.model = WatsonTableModel(self.client)
+
         if self.client.is_started:
             self.stop_watson(message="last session not closed correctly.",
                              tags=['error'])
@@ -200,9 +201,11 @@ class QWatson(QWidget):
             self.elap_timer.stop()
             self.stop_watson(message=self.activity_input_dial.comment,
                              project=self.activity_input_dial.project,
-                             tags=self.activity_input_dial.tags)
+                             tags=self.activity_input_dial.tags,
+                             round_to=ROUNDMIN[self.round_time_btn.text()])
 
-    def stop_watson(self, message=None, project=None, tags=None):
+    def stop_watson(self, message=None, project=None, tags=None,
+                    round_to=5):
         """Stop Watson and update the table model."""
         if message is not None:
             self.client._current['message'] = message
@@ -216,7 +219,7 @@ class QWatson(QWidget):
         self.client.stop()
 
         # Round the start and stop times of the last added frame.
-        round_frame_at(self.client, -1, ROUNDMIN[self.round_time_btn.text()])
+        round_frame_at(self.client, -1, round_to)
 
         self.client.save()
         self.model.endInsertRows()

--- a/qwatson/models/tablemodels.py
+++ b/qwatson/models/tablemodels.py
@@ -168,6 +168,7 @@ class WatsonTableModel(QAbstractTableModel):
         self.beginRemoveRows(index.parent(), index.row(), index.row())
         frame_id = self.frames[index.row()].id
         del self.client.frames[frame_id]
+        self.client.save()
         self.endRemoveRows()
 
     def editFrame(self, index, start=None, stop=None, project=None,


### PR DESCRIPTION
When the state file was not empty, the application was crashing.

Also added :
- Test to assert the application is starting correctly when the state file is not empty.
- Test to assert that deleting a frame from the overview table is working as expected.