### PR TITLE
PR: Ask the user what to do in a dialog when closing QWatson and an activity is running.

### DIFF
--- a/qwatson/dialogs/closedialog.py
+++ b/qwatson/dialogs/closedialog.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+# ---- Standard imports
+
+import sys
+
+# ---- Third party imports
+
+from PyQt5.QtCore import pyqtSlot as QSlot
+from PyQt5.QtWidgets import (QApplication, QDialogButtonBox,
+                             QVBoxLayout, QStyleOption, QPushButton,
+                             QAbstractButton)
+
+# ---- Local imports
+
+
+from qwatson.utils.icons import get_standard_icon, get_standard_iconsize
+from qwatson.widgets.layout import InfoBox, ColoredFrame
+
+
+class CloseDialog(ColoredFrame):
+    """
+    A dialog to ask the user to stop the time tracker if an activity
+    is running when closing.
+    """
+
+    def __init__(self, parent=None):
+        super(CloseDialog, self).__init__(parent)
+        self.set_background_color('light')
+        self.main = None
+        self.setup()
+
+    # ---- Setup layout
+
+    def setup(self):
+        """Setup the dialog widgets and layout."""
+        self.button_box = self.setup_dialog_button_box()
+        info_text = ("<b>QWatson is currently tracking an activity.</b>"
+                     "<br><br>"
+                     "Do you want to stop and save the activity<br>"
+                     "before leaving?"
+                     "<br><br>"
+                     "The activity will be cancelled otherwise."
+                     )
+
+        info_box = InfoBox(info_text, 'question', 'messagebox')
+        info_box.setContentsMargins(10, 10, 10, 10)
+
+        # Setup the layout of the dialog
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        layout.addStretch(50)
+        layout.addWidget(info_box)
+        layout.addStretch(100)
+        layout.addWidget(self.button_box)
+
+    def setup_dialog_button_box(self):
+        """Setup the buttons of the dialog."""
+        self.yes_btn = QPushButton("Yes")
+        self.yes_btn.setDefault(True)
+        self.no_btn = QPushButton("No")
+        self.cancel_btn = QPushButton("Cancel")
+
+        button_box = QDialogButtonBox()
+        button_box.addButton(self.yes_btn, QDialogButtonBox.ActionRole)
+        button_box.addButton(self.no_btn, QDialogButtonBox.ActionRole)
+        button_box.addButton(self.cancel_btn, QDialogButtonBox.ActionRole)
+        button_box.clicked.connect(self.receive_answer)
+        button_box.layout().setContentsMargins(5, 10, 5, 10)
+        button_box.setAutoFillBackground(True)
+
+        color = QStyleOption().palette.window().color()
+        palette = button_box.palette()
+        palette.setColor(button_box.backgroundRole(), color)
+        button_box.setPalette(palette)
+
+        return button_box
+
+    # ---- Bind dialog with main
+
+    def register_dialog_to(self, main):
+        """Register the dialog to the main application."""
+        if main is not None:
+            self.main = main
+            self.dialog_index = self.main.addWidget(self)
+
+    def show(self):
+        """Qt method override."""
+        if self.main is not None:
+            self.main.setCurrentIndex(self.dialog_index)
+        super(CloseDialog, self).show()
+
+    @QSlot(QAbstractButton)
+    def receive_answer(self, button):
+        """
+        Handle when the dialog question is accepted or canceled by the user.
+        """
+        if self.main is not None:
+            if button == self.yes_btn:
+                self.main.btn_startstop.setValue(False)
+                self.main.close()
+            elif button == self.no_btn:
+                self.main.cancel_watson()
+                self.main.client.save()
+                self.main.close()
+            elif button == self.cancel_btn:
+                self.main.setCurrentIndex(0)
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    date_time_dialog = CloseDialog()
+    date_time_dialog.setFixedSize(300, 162)
+    date_time_dialog.show()
+    app.exec_()

--- a/qwatson/dialogs/closedialog.py
+++ b/qwatson/dialogs/closedialog.py
@@ -113,7 +113,8 @@ class CloseDialog(ColoredFrame):
                 self.main.client.save()
                 self.main.close()
             elif button == self.cancel_btn:
-                self.main.setCurrentIndex(0)
+                pass
+            self.main.setCurrentIndex(0)
 
 
 if __name__ == '__main__':

--- a/qwatson/dialogs/datetimedialog.py
+++ b/qwatson/dialogs/datetimedialog.py
@@ -15,8 +15,10 @@ import sys
 import arrow
 from PyQt5.QtCore import pyqtSlot as QSlot
 from PyQt5.QtCore import QDateTime, Qt
+from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (QApplication, QDateTimeEdit, QDialogButtonBox,
-                             QLabel, QVBoxLayout, QStyleOption, QHBoxLayout)
+                             QLabel, QVBoxLayout, QStyleOption, QHBoxLayout,
+                             QMessageBox, QStyle)
 
 # ---- Local imports
 
@@ -50,7 +52,7 @@ class DateTimeInputDialog(ColoredFrame):
                      " the current time")
         info_box = InfoBox(info_text, 'info', 'small')
         info_box.set_background_color('light')
-        info_box.setContentsMargins(5, 5, 5, 5)
+        info_box.setContentsMargins(5, 10, 5, 10)
 
         # Setup the layout of the dialog
 
@@ -59,9 +61,9 @@ class DateTimeInputDialog(ColoredFrame):
         layout.setSpacing(0)
 
         layout.addWidget(datetime_box)
-        layout.addWidget(self.button_box)
         layout.addWidget(info_box)
-        layout.addStretch(100)
+        layout.addWidget(self.button_box)
+        layout.setStretch(1, 100)
 
     def setup_datetime_box(self):
         """Setup the datetime edit widget and a label."""
@@ -84,7 +86,7 @@ class DateTimeInputDialog(ColoredFrame):
         datetime_box = ColoredFrame()
         datetime_box.set_background_color('window')
         layout = QHBoxLayout(datetime_box)
-        layout.setContentsMargins(5, 10, 5, 5)
+        layout.setContentsMargins(5, 10, 5, 10)
         layout.setSpacing(15)
         layout.addWidget(label)
         layout.addWidget(datetime_edit)
@@ -100,7 +102,7 @@ class DateTimeInputDialog(ColoredFrame):
             lambda: self.receive_answer(QDialogButtonBox.Ok))
         button_box.rejected.connect(
             lambda: self.receive_answer(QDialogButtonBox.Cancel))
-        button_box.layout().setContentsMargins(5, 5, 5, 10)
+        button_box.layout().setContentsMargins(5, 10, 5, 10)
         button_box.setAutoFillBackground(True)
 
         color = QStyleOption().palette.window().color()
@@ -122,7 +124,6 @@ class DateTimeInputDialog(ColoredFrame):
         """Qt method override."""
         self.set_datetime_to_now()
         if self.main is not None:
-            self.main.start_from.setEnabled(False)
             frames = self.main.client.frames
             self.main.setCurrentIndex(self.dialog_index)
             self.set_datetime_minimum(
@@ -139,7 +140,6 @@ class DateTimeInputDialog(ColoredFrame):
                 self.main.start_watson(start_time=self.get_datetime_arrow())
             elif button == QDialogButtonBox.Cancel:
                 self.main.cancel_watson()
-            self.main.start_from.setEnabled(True)
             self.main.setCurrentIndex(0)
 
     # ---- Utility

--- a/qwatson/dialogs/datetimedialog.py
+++ b/qwatson/dialogs/datetimedialog.py
@@ -15,10 +15,8 @@ import sys
 import arrow
 from PyQt5.QtCore import pyqtSlot as QSlot
 from PyQt5.QtCore import QDateTime, Qt
-from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (QApplication, QDateTimeEdit, QDialogButtonBox,
-                             QLabel, QVBoxLayout, QStyleOption, QHBoxLayout,
-                             QMessageBox, QStyle)
+                             QLabel, QVBoxLayout, QStyleOption, QHBoxLayout)
 
 # ---- Local imports
 
@@ -50,9 +48,10 @@ class DateTimeInputDialog(ColoredFrame):
         info_text = ("The start time cannot be sooner than the stop\n"
                      " time of the last saved activity and later than\n"
                      " the current time")
-        info_box = InfoBox(info_text, 'info', 'small')
-        info_box.set_background_color('light')
+
+        info_box = InfoBox(info_text, 'information', 'small')
         info_box.setContentsMargins(5, 10, 5, 10)
+        info_box.setSpacing(10)
 
         # Setup the layout of the dialog
 
@@ -61,9 +60,9 @@ class DateTimeInputDialog(ColoredFrame):
         layout.setSpacing(0)
 
         layout.addWidget(datetime_box)
-        layout.addWidget(info_box)
         layout.addWidget(self.button_box)
-        layout.setStretch(1, 100)
+        layout.addWidget(info_box)
+        layout.setStretch(2, 100)
 
     def setup_datetime_box(self):
         """Setup the datetime edit widget and a label."""

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -230,6 +230,10 @@ class QWatson(QWidget):
         self.stackwidget.addWidget(widget)
         return self.stackwidget.count() - 1
 
+    def currentIndex(self):
+        """Return the current index of the stackwidget."""
+        return self.stackwidget.currentIndex()
+
     def setCurrentIndex(self, index):
         """Set the current index of the stackwidget."""
         self.stackwidget.setCurrentIndex(index)

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -17,7 +17,7 @@ import os.path as osp
 from PyQt5.QtCore import Qt, QModelIndex
 from PyQt5.QtWidgets import (QApplication, QGridLayout, QHBoxLayout,
                              QSizePolicy, QWidget, QStackedWidget,
-                             QVBoxLayout)
+                             QVBoxLayout, QMessageBox)
 
 # ---- Local imports
 
@@ -76,33 +76,30 @@ class QWatson(QWidget):
         self.stackwidget = QStackedWidget()
         self.setup_activity_tracker()
         self.setup_datetime_input_dial()
-
         self.stackwidget.setCurrentIndex(0)
 
-        # Setup the statusbar
-        statusbar = self.setup_statusbar()
-
         # Setup the main layout of the widget
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
         layout.addWidget(self.stackwidget)
-        layout.addWidget(statusbar)
-        layout.setStretch(0, 100)
 
     def setup_activity_tracker(self):
         """Setup the widget used to start, track, and stop new activity."""
         timebar = self.setup_timebar()
         self.activity_input_dial = self.setup_activity_input_dial()
+        statusbar = self.setup_statusbar()
 
         # ---- Setup the layout of the main widget
 
         tracker = QWidget()
-        layout = QGridLayout(tracker)
+        layout = QVBoxLayout(tracker)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        layout.addWidget(self.activity_input_dial, 1, 0)
-        layout.addWidget(timebar, 0, 0)
+        layout.addWidget(timebar)
+        layout.addWidget(self.activity_input_dial)
+        layout.addWidget(statusbar)
+        layout.setStretch(1, 100)
 
         self.stackwidget.addWidget(tracker)
 
@@ -204,6 +201,7 @@ class QWatson(QWidget):
         statusbar.set_background_color('window')
 
         layout = QHBoxLayout(statusbar)
+        layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.round_time_btn)
         layout.addWidget(self.start_from)

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -33,6 +33,7 @@ from qwatson import __namever__
 from qwatson.models.tablemodels import WatsonTableModel
 from qwatson.dialogs.activitydialog import ActivityInputDialog
 from qwatson.dialogs.datetimedialog import DateTimeInputDialog
+from qwatson.dialogs.closedialog import CloseDialog
 from qwatson.widgets.layout import ColoredFrame
 
 ROUNDMIN = {'round to 1min': 1, 'round to 5min': 5, 'round to 10min': 10}
@@ -76,6 +77,7 @@ class QWatson(QWidget):
         self.stackwidget = QStackedWidget()
         self.setup_activity_tracker()
         self.setup_datetime_input_dial()
+        self.setup_close_dial()
         self.stackwidget.setCurrentIndex(0)
 
         # Setup the main layout of the widget
@@ -102,6 +104,14 @@ class QWatson(QWidget):
         layout.setStretch(1, 100)
 
         self.stackwidget.addWidget(tracker)
+
+    def setup_close_dial(self):
+        """
+        Setup a dialog that is shown when closing QWatson while and activity
+        is being tracked.
+        """
+        self.close_dial = CloseDialog(parent=self)
+        self.close_dial.register_dialog_to(self)
 
     def setup_datetime_input_dial(self):
         """
@@ -307,9 +317,13 @@ class QWatson(QWidget):
 
     def closeEvent(self, event):
         """Qt method override."""
-        self.client.save()
-        event.accept()
-        print("QWatson is closed.\n")
+        if self.client.is_started:
+            self.close_dial.show()
+            event.ignore()
+        else:
+            self.overview_widg.close()
+            event.accept()
+            print("QWatson is closed.\n")
 
 
 class WatsonOverviewWidget(QWidget):

--- a/qwatson/utils/icons.py
+++ b/qwatson/utils/icons.py
@@ -14,6 +14,7 @@ import os
 
 from PyQt5.QtCore import QSize
 from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QApplication, QStyle
 
 from qwatson import __rootdir__
 
@@ -44,3 +45,25 @@ def get_icon(name):
 
 def get_iconsize(size):
     return QSize(*ICON_SIZES[size])
+
+
+def get_standard_icon(constant):
+    """Return a QIcon of a standard pixmap."""
+    style = QApplication.instance().style()
+    if constant == 'question':
+        return style.standardIcon(QStyle.SP_MessageBoxQuestion)
+    if constant == 'information':
+        return style.standardIcon(QStyle.SP_MessageBoxInformation)
+
+
+def get_standard_iconsize(constant):
+    """
+    Return the standard size of various component of the gui.
+
+    https://srinikom.github.io/pyside-docs/PySide/QtGui/QStyle
+    """
+    style = QApplication.instance().style()
+    if constant == 'messagebox':
+        return style.pixelMetric(QStyle.PM_MessageBoxIconSize)
+    elif constant == 'small':
+        return style.pixelMetric(QStyle.PM_SmallIconSize)

--- a/qwatson/widgets/layout.py
+++ b/qwatson/widgets/layout.py
@@ -15,6 +15,7 @@ from PyQt5.QtWidgets import QFrame, QGridLayout, QLabel, QStyleOption, QWidget
 # ---- Local imports
 
 from qwatson.utils import icons
+from qwatson.utils.icons import get_standard_icon, get_standard_iconsize
 
 
 class HSep(QFrame):
@@ -57,10 +58,11 @@ class InfoBox(ColoredFrame):
     """
     A simple widget with an icon and a text area to display info to the user.
     """
-    def __init__(self,  text='', icon='info', iconsize='small', parent=None):
+    def __init__(self,  text, icon, iconsize, color='light', parent=None):
         super(InfoBox, self).__init__(parent)
-        icon = icons.get_icon(icon) if isinstance(icon, str) else icon
-        iconsize = (icons.get_iconsize(iconsize) if
+        self.set_background_color(color)
+        icon = icons.get_standard_icon(icon) if isinstance(icon, str) else icon
+        iconsize = (icons.get_standard_iconsize(iconsize) if
                     isinstance(iconsize, str) else iconsize)
 
         info_icon = QLabel()
@@ -73,14 +75,18 @@ class InfoBox(ColoredFrame):
         # Setup the layout of the info box
 
         layout = QGridLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(10)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.setSpacing(15)
 
         layout.addWidget(info_icon, 0, 0)
         layout.addWidget(info_label, 0, 1, 2, 1)
 
         layout.setRowStretch(1, 100)
         layout.setColumnStretch(1, 100)
+
+    def setSpacing(self, x):
+        """Set the spacing between the icon and the text."""
+        self.layout().setSpacing(x)
 
     def setContentsMargins(self, left, top, right, bottom):
         """Set the content margins values of the info box layout."""


### PR DESCRIPTION
Fixes #34 
When closing QWatson while an activity is being tracked, a dialog is shown to the user asking them what to do. The user have 3 choices:
- Yes : Stop and save the activity and close QWatson.
- No : Cancel the activity and close QWatson
- Cancel : Continue tracking the activity and return to QWatson main dialog.

![close_dialog_demo](https://user-images.githubusercontent.com/10170372/41780859-f1692382-7603-11e8-9046-8f1b917ff230.gif)