### PR TITLE
PR: Cancel renaming or adding new project when the Esc key is pressed

### DIFF
--- a/qwatson/tests/test_mainwindow.py
+++ b/qwatson/tests/test_mainwindow.py
@@ -51,6 +51,16 @@ def test_mainwindow_init(qtbot):
 
     qtbot.mouseClick(mainwindow.btn_report, Qt.LeftButton)
     assert mainwindow.overview_widg.isVisible()
+
+    # Check default values
+
+    activity_input_dial = mainwindow.activity_input_dial
+    assert activity_input_dial.project == ''
+    assert activity_input_dial.tags == []
+    assert activity_input_dial.comment == ''
+    assert mainwindow.round_time_btn.text() == 'round to 5min'
+    assert mainwindow.start_from.text() == 'start from now'
+
     mainwindow.close()
 
 
@@ -64,28 +74,24 @@ def test_add_first_project(qtbot, mocker):
     mainwindow.show()
     qtbot.waitForWindowShown(mainwindow)
 
-    # ---- Check default
-
     activity_input_dial = mainwindow.activity_input_dial
-    assert activity_input_dial.project == ''
-    assert activity_input_dial.tags == []
-    assert activity_input_dial.comment == ''
-    assert mainwindow.round_time_btn.text() == 'round to 5min'
-    assert mainwindow.start_from.text() == 'start from now'
 
     # ---- Setup the activity input dialog
 
     # Setup the tags
+
     qtbot.keyClicks(activity_input_dial.tag_lineedit, 'tag1, tag2, tag3')
     qtbot.keyPress(activity_input_dial.tag_lineedit, Qt.Key_Enter)
     assert activity_input_dial.tags == ['tag1', 'tag2', 'tag3']
 
     # Setup the comment
+
     qtbot.keyClicks(activity_input_dial.msg_textedit, 'First activity')
     qtbot.keyPress(activity_input_dial.msg_textedit, Qt.Key_Enter)
     assert activity_input_dial.comment == 'First activity'
 
     # Add a new project
+
     qtbot.mouseClick(
         activity_input_dial.project_manager.btn_add, Qt.LeftButton)
     qtbot.keyClicks(
@@ -166,6 +172,7 @@ def test_rename_project(qtbot, mocker):
 
     assert project_manager.project_cbox.linedit.isVisible()
     assert not project_manager.project_cbox.combobox.isVisible()
+    qtbot.keyPress(project_manager.project_cbox.linedit, Qt.Key_End)
     qtbot.keyClicks(project_manager.project_cbox.linedit, '_renamed')
     qtbot.keyPress(project_manager.project_cbox.linedit, Qt.Key_Enter)
     assert not project_manager.project_cbox.linedit.isVisible()
@@ -173,6 +180,21 @@ def test_rename_project(qtbot, mocker):
 
     assert mainwindow.activity_input_dial.project == 'project1_renamed'
     assert mainwindow.client.frames[0].project == 'project1_renamed'
+
+    # Cancel the renaming of a project by pressing Escape
+
+    qtbot.mouseClick(project_manager.btn_rename, Qt.LeftButton)
+
+    assert project_manager.project_cbox.linedit.isVisible()
+    assert not project_manager.project_cbox.combobox.isVisible()
+    qtbot.keyClicks(project_manager.project_cbox.linedit, 'dummy')
+    qtbot.keyPress(project_manager.project_cbox.linedit, Qt.Key_Escape)
+    assert not project_manager.project_cbox.linedit.isVisible()
+    assert project_manager.project_cbox.combobox.isVisible()
+
+    assert mainwindow.activity_input_dial.project == 'project1_renamed'
+    assert mainwindow.client.frames[0].project == 'project1_renamed'
+
     mainwindow.close()
 
 

--- a/qwatson/widgets/comboboxes.py
+++ b/qwatson/widgets/comboboxes.py
@@ -146,3 +146,12 @@ class ComboBoxEdit(QWidget):
         self.combobox.setVisible(self._edit_mode is None)
         self.combobox.setFocus(self._edit_mode is None)
 
+
+if __name__ == '__main__':
+    import sys
+    app = QApplication(sys.argv)
+    comboboxedit = ComboBoxEdit()
+    comboboxedit.addItems(['item1', 'item2', 'item3'])
+    comboboxedit.setCurentText('item1')
+    comboboxedit.show()
+    app.exec_()

--- a/qwatson/widgets/comboboxes.py
+++ b/qwatson/widgets/comboboxes.py
@@ -10,7 +10,8 @@
 
 from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtCore import Qt, QEvent
-from PyQt5.QtWidgets import (QGridLayout, QLineEdit, QComboBox, QWidget)
+from PyQt5.QtWidgets import (QApplication, QGridLayout, QLineEdit, QComboBox,
+                             QWidget)
 
 
 class ComboBoxEdit(QWidget):
@@ -20,7 +21,11 @@ class ComboBoxEdit(QWidget):
 
     def __init__(self, parent=None):
         super(ComboBoxEdit, self).__init__(parent)
-        self._edit_mode = ''
+        self._edit_mode = None
+        self.setup()
+
+    def setup(self):
+        """Setup the combobox edit."""
 
         self.linedit = QLineEdit()
         self.linedit.setVisible(False)
@@ -127,6 +132,6 @@ class ComboBoxEdit(QWidget):
             elif mode == 'add':
                 self.linedit.clear()
         else:
-            self._edit_mode_edit_mode = None
+            self._edit_mode = None
         self.linedit.setVisible(self._edit_mode is not None)
         self.combobox.setVisible(self._edit_mode is None)

--- a/qwatson/widgets/comboboxes.py
+++ b/qwatson/widgets/comboboxes.py
@@ -103,6 +103,14 @@ class ComboBoxEdit(QWidget):
         """Add the items to the combobox."""
         self.combobox.addItems(items)
 
+    def count(self):
+        """Return the number of items listed in the combobox."""
+        return self.combobox.count()
+
+    def items(self):
+        """Return a list of all the items listed in the combobox."""
+        return [self.combobox.itemText(i) for i in range(self.count())]
+
     def removeItem(self, index):
         """Remove the item at the specified index in the combobox."""
         self.combobox.removeItem(index)

--- a/qwatson/widgets/comboboxes.py
+++ b/qwatson/widgets/comboboxes.py
@@ -142,4 +142,7 @@ class ComboBoxEdit(QWidget):
         else:
             self._edit_mode = None
         self.linedit.setVisible(self._edit_mode is not None)
+        self.linedit.setFocus(self._edit_mode is not None)
         self.combobox.setVisible(self._edit_mode is None)
+        self.combobox.setFocus(self._edit_mode is None)
+

--- a/qwatson/widgets/tests/test_comboboxes.py
+++ b/qwatson/widgets/tests/test_comboboxes.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+# ---- Standard imports
+
+import os
+import os.path as osp
+
+# ---- Third party imports
+
+import pytest
+from PyQt5.QtCore import Qt
+
+# ---- Local imports
+
+from qwatson.widgets.comboboxes import ComboBoxEdit
+
+
+WORKDIR = osp.dirname(__file__)
+FRAMEFILE = osp.join(WORKDIR, 'frames')
+STATEFILE = osp.join(WORKDIR, 'state')
+
+
+# ---- Test ComboBoxEdit
+
+def test_comboboxedit_basic(qtbot):
+    """Basic tests on the ComboBoxEdit widget."""
+    comboboxedit = ComboBoxEdit()
+
+    # Test adding items
+
+    comboboxedit.addItems(['item1', 'item2', 'item3'])
+    assert comboboxedit.items() == ['item1', 'item2', 'item3']
+
+    # Test removing items
+
+    comboboxedit.removeItem(4)
+    assert comboboxedit.items() == ['item1', 'item2', 'item3']
+    comboboxedit.removeItem(1)
+    assert comboboxedit.items() == ['item1', 'item3']
+
+    # Test current
+
+    comboboxedit.setCurentText('item3')
+    assert comboboxedit.currentIndex() == 1
+    comboboxedit.currentText() == 'item3'
+
+    # Test clear items
+
+    comboboxedit.clear()
+    assert comboboxedit.items() == []
+
+
+def test_comboboxedit_edit(qtbot):
+    """Test that adding and editing items works as expected."""
+    comboboxedit = ComboBoxEdit()
+    comboboxedit.show()
+    qtbot.addWidget(comboboxedit)
+    qtbot.waitForWindowShown(comboboxedit)
+
+    comboboxedit.addItems(['item1', 'item2', 'item3'])
+    comboboxedit.setCurentText('item1')
+
+    # Test edit mode None.
+
+    comboboxedit.set_edit_mode('dummy')
+    assert not comboboxedit.linedit.isVisible()
+    assert comboboxedit.combobox.isVisible()
+
+    # Add an already existing item and press Enter.
+
+    comboboxedit.set_edit_mode('add')
+    assert comboboxedit.linedit.isVisible()
+    assert not comboboxedit.combobox.isVisible()
+    assert comboboxedit.linedit.text() == ''
+
+    qtbot.keyClicks(comboboxedit.linedit, 'item2')
+    qtbot.keyPress(comboboxedit.linedit, Qt.Key_Enter)
+    assert comboboxedit.items() == ['item1', 'item2', 'item3']
+    assert comboboxedit.currentText() == 'item2'
+    assert not comboboxedit.linedit.isVisible()
+    assert comboboxedit.combobox.isVisible()
+
+    # Add a new item and clear focus.
+
+    comboboxedit.set_edit_mode('add')
+    qtbot.keyClicks(comboboxedit.linedit, 'item4')
+    comboboxedit.linedit.clearFocus()
+    assert comboboxedit.items() == ['item1', 'item2', 'item3', 'item4']
+    assert comboboxedit.currentText() == 'item4'
+    assert not comboboxedit.linedit.isVisible()
+    assert comboboxedit.combobox.isVisible()
+
+    # Cancel the adding of a new item by pressing Escape
+
+    comboboxedit.set_edit_mode('add')
+    qtbot.keyClicks(comboboxedit.linedit, 'item5')
+    qtbot.keyPress(comboboxedit.linedit, Qt.Key_Escape)
+    assert comboboxedit.items() == ['item1', 'item2', 'item3', 'item4']
+    assert comboboxedit.currentText() == 'item4'
+    assert not comboboxedit.linedit.isVisible()
+    assert comboboxedit.combobox.isVisible()
+
+    # Rename an item and press Enter
+
+    comboboxedit.set_edit_mode('rename')
+    assert comboboxedit.linedit.text() == 'item4'
+    qtbot.keyPress(comboboxedit.linedit, Qt.Key_End)
+    qtbot.keyClicks(comboboxedit.linedit, 'b')
+    qtbot.keyPress(comboboxedit.linedit, Qt.Key_Enter)
+    assert comboboxedit.items() == ['item1', 'item2', 'item3', 'item4b']
+    assert comboboxedit.currentText() == 'item4b'
+    assert not comboboxedit.linedit.isVisible()
+    assert comboboxedit.combobox.isVisible()
+
+    # Rename an item to an already existing item and press Enter
+
+    comboboxedit.set_edit_mode('rename')
+    qtbot.keyClicks(comboboxedit.linedit, 'item1')
+    qtbot.keyPress(comboboxedit.linedit, Qt.Key_Enter)
+    assert comboboxedit.items() == ['item1', 'item2', 'item3']
+    assert comboboxedit.currentText() == 'item1'
+    assert not comboboxedit.linedit.isVisible()
+    assert comboboxedit.combobox.isVisible()
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])


### PR DESCRIPTION
Fixes #42 
- [x] Cancel adding a new project by pressing <kbd>Esc</kbd>
- [x] Cancel renaming a project by pressing <kbd>Esc</kbd>
- [x] Add Ci-tests

![esc_to_cancel](https://user-images.githubusercontent.com/10170372/42121530-947539ee-7bfe-11e8-84de-f62af95eae14.gif)