### PR TITLE
PR: Row highlighting and style of the activity oververview table

### DIFF
--- a/qwatson/dialogs/basedialog.py
+++ b/qwatson/dialogs/basedialog.py
@@ -29,9 +29,8 @@ class BaseDialog(ColoredFrame):
     """
 
     def __init__(self, main=None, parent=None):
-        super(BaseDialog, self).__init__(parent)
+        super(BaseDialog, self).__init__(color='light', parent=parent)
         self.answer = None
-        self.set_background_color('light')
         self.register_dialog_to(main)
         self.button_box = self.setup_dialog_button_box()
         self.buttons = {}

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -25,8 +25,7 @@ from qwatson.watson.watson import Watson
 from qwatson.utils import icons
 from qwatson.utils.watsonhelpers import round_frame_at
 from qwatson.widgets.clock import ElapsedTimeLCDNumber
-from qwatson.widgets.dates import DateRangeNavigator
-from qwatson.widgets.tableviews import WatsonDailyTableWidget
+from qwatson.widgets.tableviews import WatsonOverviewWidget
 from qwatson.widgets.toolbar import (
     OnOffToolButton, QToolButtonSmall, DropDownToolButton)
 from qwatson import __namever__
@@ -334,46 +333,6 @@ class QWatson(QWidget, QWatsonImportMixin):
             self.overview_widg.close()
             event.accept()
             print("QWatson is closed.\n")
-
-
-class WatsonOverviewWidget(QWidget):
-    """A widget to show and edit activities logged with Watson."""
-    def __init__(self, client, model, parent=None):
-        super(WatsonOverviewWidget, self).__init__(parent)
-        self.setWindowIcon(icons.get_icon('master'))
-        self.setWindowTitle("Activity Overview")
-
-        self.setup(model)
-        self.date_span_changed()
-
-    def setup(self, model):
-        """Setup the widget with the provided arguments."""
-        self.table_widg = WatsonDailyTableWidget(model, parent=self)
-
-        self.date_range_nav = DateRangeNavigator()
-        self.date_range_nav.sig_date_span_changed.connect(
-            self.date_span_changed)
-
-        # ---- Setup the layout
-
-        layout = QGridLayout(self)
-        layout.addWidget(self.date_range_nav)
-        layout.addWidget(self.table_widg)
-
-    def date_span_changed(self):
-        """Handle when the range of the date range navigator widget change."""
-        self.table_widg.set_date_span(self.date_range_nav.current)
-
-    def show(self):
-        """Qt method override."""
-        super(WatsonOverviewWidget, self).show()
-        if self.windowState() & Qt.WindowMaximized:
-            self.setWindowState(Qt.WindowActive | Qt.WindowMaximized)
-        else:
-            self.setWindowState(Qt.WindowActive)
-        self.activateWindow()
-        self.raise_()
-        self.setFocus()
 
 
 if __name__ == '__main__':

--- a/qwatson/models/delegates.py
+++ b/qwatson/models/delegates.py
@@ -9,7 +9,7 @@
 # ---- Third parties imports
 
 from PyQt5.QtCore import QEvent, QRect, QPoint, Qt
-
+from PyQt5.QtGui import QPalette
 from PyQt5.QtWidgets import (
     QApplication, QComboBox, QDateTimeEdit, QLineEdit, QStyle,
     QStyledItemDelegate, QStyleOptionToolButton, QListView)
@@ -61,6 +61,13 @@ class BaseDelegate(QStyledItemDelegate):
         # Set the options for the focus rectangle.
 
         option.state |= QStyle.State_KeyboardFocusChange
+
+        # We fill the background with a solid color before painting the
+        # control to override any painting that could have been done by
+        # the table view.
+
+        brush = option.palette.brush(QPalette.Normal, QPalette.Window)
+        painter.fillRect(option.rect, brush)
 
         style.drawControl(QStyle.CE_ItemViewItem, option, painter, widget)
 

--- a/qwatson/models/delegates.py
+++ b/qwatson/models/delegates.py
@@ -8,10 +8,11 @@
 
 # ---- Third parties imports
 
-from PyQt5.QtCore import (QEvent, QRect, QPoint, Qt)
+from PyQt5.QtCore import QEvent, QRect, QPoint, Qt
+
 from PyQt5.QtWidgets import (
     QApplication, QComboBox, QDateTimeEdit, QLineEdit, QStyle,
-    QStyledItemDelegate, QStyleOptionToolButton)
+    QStyledItemDelegate, QStyleOptionToolButton, QListView)
 
 # ---- Local imports
 
@@ -22,6 +23,48 @@ from qwatson.widgets.tags import TagLineEdit
 
 
 class TagEditDelegate(QStyledItemDelegate):
+class BaseDelegate(QStyledItemDelegate):
+
+    def __init__(self, parent):
+        super(BaseDelegate, self) .__init__(parent)
+
+    def paint(self, painter, option, index):
+        widget = QListView()
+        style = widget.style()
+
+        # A row can be highlighted only if the parent tableview is selected.
+
+        if not self.parent().is_selected:
+            option.state &= ~QStyle.State_Selected
+
+        # Set the options for mouse hover highlight.
+
+        if self.parent()._hovered_row == index.row():
+            option.state |= QStyle.State_MouseOver
+        else:
+            option.state &= ~QStyle.State_MouseOver
+
+        if index.column() == 0:
+            option.viewItemPosition = 1
+        elif index.column() == self.parent().model().columnCount()-1:
+            option.viewItemPosition = 3
+        else:
+            option.viewItemPosition = 2
+
+        # Set the options for the text.
+
+        option.text = index.data()
+        if index.data(Qt.TextAlignmentRole) & Qt.AlignLeft:
+            option.displayAlignment = Qt.AlignLeft | Qt.AlignVCenter
+        else:
+            option.displayAlignment = Qt.AlignCenter | Qt.AlignVCenter
+
+        # Set the options for the focus rectangle.
+
+        option.state |= QStyle.State_KeyboardFocusChange
+
+        style.drawControl(QStyle.CE_ItemViewItem, option, painter, widget)
+
     """
     A delegate that allow to edit the tags of a frame and
     force an update of the Watson data via the model.

--- a/qwatson/models/delegates.py
+++ b/qwatson/models/delegates.py
@@ -22,7 +22,6 @@ from qwatson.utils.strformating import list_to_str
 from qwatson.widgets.tags import TagLineEdit
 
 
-class TagEditDelegate(QStyledItemDelegate):
 class BaseDelegate(QStyledItemDelegate):
 
     def __init__(self, parent):
@@ -65,12 +64,14 @@ class BaseDelegate(QStyledItemDelegate):
 
         style.drawControl(QStyle.CE_ItemViewItem, option, painter, widget)
 
+
+class TagEditDelegate(BaseDelegate):
     """
     A delegate that allow to edit the tags of a frame and
     force an update of the Watson data via the model.
     """
     def __init__(self, parent):
-        QStyledItemDelegate.__init__(self, parent)
+        super(TagEditDelegate, self).__init__(parent)
 
     def createEditor(self, parent, option, index):
         """Qt method override."""
@@ -87,14 +88,14 @@ class BaseDelegate(QStyledItemDelegate):
             model.editFrame(index, tags=editor.tags)
 
 
-class ToolButtonDelegate(QStyledItemDelegate):
+class ToolButtonDelegate(BaseDelegate):
     """
     A delegate that draws a tool button in the middle of a table cell that
     emits a signal of the model when clicked.
     """
 
     def __init__(self, parent):
-        QStyledItemDelegate.__init__(self, parent)
+        super(ToolButtonDelegate, self).__init__(parent)
 
     def createEditor(self, parent, option, index):
         """Qt method override to prevent the creation of an editor."""
@@ -102,11 +103,13 @@ class ToolButtonDelegate(QStyledItemDelegate):
 
     def paint(self, painter, option, index):
         """Paint a toolbutton with an icon."""
+        super(ToolButtonDelegate, self).paint(painter, option, index)
+
         opt = QStyleOptionToolButton()
         opt.rect = self.get_btn_rect(option)
-        opt.icon = icons.get_icon('erase-right')
         opt.iconSize = icons.get_iconsize('small')
         opt.state |= QStyle.State_Enabled | QStyle.State_Raised
+        opt.icon = icons.get_icon('erase-right')
 
         QApplication.style().drawControl(
             QStyle.CE_ToolButtonLabel, opt, painter)
@@ -130,14 +133,14 @@ class ToolButtonDelegate(QStyledItemDelegate):
                        event, model, option, index)
 
 
-class LineEditDelegate(QStyledItemDelegate):
+class LineEditDelegate(BaseDelegate):
     """
     A delegate that allow to edit the text of a table cell and
     force an update of the Watson data via the model.
     """
 
     def __init__(self, parent):
-        QStyledItemDelegate.__init__(self, parent)
+        super(LineEditDelegate, self) .__init__(parent)
 
     def createEditor(self, parent, option, index):
         """Qt method override."""
@@ -154,14 +157,14 @@ class LineEditDelegate(QStyledItemDelegate):
             model.editFrame(index, message=editor.text())
 
 
-class ComboBoxDelegate(QStyledItemDelegate):
+class ComboBoxDelegate(BaseDelegate):
     """
     A delegate that allow to change the project of an activity from a
     combobox and force an update of the Watson data via the model.
     """
 
     def __init__(self, parent):
-        QStyledItemDelegate.__init__(self, parent)
+        super(ComboBoxDelegate, self) .__init__(parent)
 
     def createEditor(self, parent, option, index):
         """Qt method override."""
@@ -178,14 +181,14 @@ class ComboBoxDelegate(QStyledItemDelegate):
             model.editFrame(index, project=editor.currentText())
 
 
-class DateTimeDelegate(QStyledItemDelegate):
+class DateTimeDelegate(BaseDelegate):
     """
     A delegate that allow to edit the time of a table cell and force an
     update of the Watson data via the model.
     """
 
     def __init__(self, parent):
-        QStyledItemDelegate.__init__(self, parent)
+        super(DateTimeDelegate, self) .__init__(parent)
 
     def createEditor(self, parent, option, index):
         """Qt method override."""

--- a/qwatson/models/delegates.py
+++ b/qwatson/models/delegates.py
@@ -65,9 +65,7 @@ class BaseDelegate(QStyledItemDelegate):
         # We fill the background with a solid color before painting the
         # control to override any painting that could have been done by
         # the table view.
-
-        brush = option.palette.brush(QPalette.Normal, QPalette.Window)
-        painter.fillRect(option.rect, brush)
+        painter.fillRect(option.rect, index.data(Qt.BackgroundRole))
 
         style.drawControl(QStyle.CE_ItemViewItem, option, painter, widget)
 

--- a/qwatson/models/tablemodels.py
+++ b/qwatson/models/tablemodels.py
@@ -115,9 +115,9 @@ class WatsonTableModel(QAbstractTableModel):
     def flags(self, index):
         """Qt method override."""
         if index.column() in self.EDIT_COLUMNS:
-            return Qt.ItemIsEnabled | Qt.ItemIsEditable
+            return Qt.ItemIsEnabled | Qt.ItemIsEditable | Qt.ItemIsSelectable
         else:
-            return Qt.ItemIsEnabled
+            return Qt.ItemIsEnabled | Qt.ItemIsSelectable
 
     # ---- Utils
 

--- a/qwatson/models/tablemodels.py
+++ b/qwatson/models/tablemodels.py
@@ -20,6 +20,7 @@ from PyQt5.QtCore import (QAbstractTableModel, QModelIndex,
 
 # ---- Local imports
 
+from qwatson.utils import colors
 from qwatson.utils.dates import qdatetime_from_str
 from qwatson.utils.strformating import list_to_str
 from qwatson.utils.watsonhelpers import edit_frame_at
@@ -93,6 +94,8 @@ class WatsonTableModel(QAbstractTableModel):
                 return frames[index.row()].project
             elif index.column() == self.COLUMNS['tags']:
                 return list_to_str(frames[index.row()].tags)
+        elif role == Qt.BackgroundRole:
+            return colors.get_qcolor('base')
         elif role == Qt.TextAlignmentRole:
             if index.column() == self.COLUMNS['comment']:
                 return Qt.AlignLeft | Qt.AlignVCenter

--- a/qwatson/utils/colors.py
+++ b/qwatson/utils/colors.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+
+# ---- Imports: third parties
+
+from PyQt5.QtGui import QColor, QPalette
+from PyQt5.QtWidgets import QStyleOption
+
+
+def get_qcolor(*args):
+    """
+    Return a QColor either from a RGB tuple of int, a RGB Hex Code,
+    a supported Qt color name, or a QPalette color group.
+
+    https://srinikom.github.io/pyside-docs/PySide/QtGui/QPalette.html
+    https://srinikom.github.io/pyside-docs/PySide/QtGui/QColor.html
+    """
+    if isinstance(args[0], QColor):
+        return args[0]
+
+    if isinstance(args[0], tuple):
+        return QColor(*args[0])
+
+    if isinstance(args[0], str):
+        if args[0].startswith('#') or args[0] in QColor.colorNames():
+            return QColor(args[0])
+
+        try:
+            return getattr(QStyleOption().palette, args[0])().color()
+        except AttributeError:
+            pass
+
+    raise ValueError("The provided color argument is not valid")
+
+
+def set_widget_palette(widget, bgcolor=None, fgcolor=None):
+    """Set the background and foreground color of the widget."""
+    p = widget.palette()
+    if bgcolor is not None:
+        p.setColor(widget.backgroundRole(), get_qcolor(bgcolor))
+    if fgcolor is not None:
+        p.setColor(widget.foregroundRole(), get_qcolor(fgcolor))
+    widget.setPalette(p)

--- a/qwatson/utils/tests/test_colors.py
+++ b/qwatson/utils/tests/test_colors.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+# ---- Standard imports
+
+import os
+
+# ---- Third party imports
+
+import pytest
+
+# ---- Local imports
+
+from qwatson.utils.colors import get_qcolor, set_widget_palette
+from PyQt5.QtGui import QColor, QPalette
+from PyQt5.QtWidgets import QLabel
+
+
+def test_get_qcolor(qtbot):
+    """
+    Test that the various available methods to create a QColor are working
+    as expected.
+    """
+    qcolor = QColor('red')
+    assert get_qcolor(QColor('red')) == qcolor
+    assert get_qcolor('red') == qcolor
+    assert get_qcolor((255, 0, 0)) == qcolor
+    assert get_qcolor('#FF0000') == qcolor
+    assert get_qcolor('window') == QPalette().window().color()
+    with pytest.raises(ValueError):
+        get_qcolor('dummy')
+
+
+def test_set_widget_palette(qtbot):
+    """
+    Asser that setting the background and foreground colors for widgets works
+    as expected.
+    """
+    qlabel = QLabel('Coucou')
+    qlabel.setAutoFillBackground(True)
+
+    set_widget_palette(qlabel, bgcolor='black', fgcolor='red')
+    assert qlabel.palette().color(qlabel.backgroundRole()) == QColor('black')
+    assert qlabel.palette().color(qlabel.foregroundRole()) == QColor('red')
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])

--- a/qwatson/widgets/layout.py
+++ b/qwatson/widgets/layout.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (QApplication, QFrame, QGridLayout, QLabel,
 # ---- Local imports
 
 from qwatson.utils import icons
+from qwatson.utils import colors
 
 
 class HSep(QFrame):
@@ -40,18 +41,10 @@ class ColoredFrame(QFrame):
     def __init__(self, color=None, parent=None):
         super(ColoredFrame, self).__init__(parent)
         self.setAutoFillBackground(True)
+        self.set_background_color(color)
 
     def set_background_color(self, colorname):
-        if colorname == 'light':
-            color = QStyleOption().palette.light().color()
-        elif colorname == 'window':
-            color = QStyleOption().palette.window().color()
-        else:
-            color = QStyleOption().palette.base().color()
-
-        palette = self.palette()
-        palette.setColor(self.backgroundRole(), color)
-        self.setPalette(palette)
+        colors.set_widget_palette(self, bgcolor=colorname)
 
 
 class CollapsableScrollArea(QScrollArea):

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -413,6 +413,6 @@ if __name__ == '__main__':
     model = WatsonTableModel(client)
 
     app = QApplication(sys.argv)
-    date_range_nav = WatsonDailyTableWidget(model)
-    date_range_nav.show()
+    overview_window = WatsonOverviewWidget(client, model)
+    overview_window.show()
     app.exec_()

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -272,6 +272,13 @@ class WatsonTableWidget(QWidget):
         """Return the index of the selected row in the view."""
         return self.view.get_selected_row()
 
+    def get_selected_frame_index(self):
+        """
+        Return the index of the frame corresponding to the selected row if
+        there is one, else return None.
+        """
+        return self.view.get_selected_frame_index()
+
 
 # ---- TableView
 
@@ -395,12 +402,22 @@ class FormatedWatsonTableView(BasicWatsonTableView):
 
     def get_selected_row(self):
         """
-        Return the index of the selected row if there is one, return
+        Return the index of the selected row if there is one and return
         None otherwise.
         """
         if self.is_selected:
-            indexes = self.selectionModel().selectedRows()
-            return indexes[0].row()
+            return self.selectionModel().selectedRows()[0].row()
+        else:
+            return None
+
+    def get_selected_frame_index(self):
+        """
+        Return the index of the frame corresponding to the selected row if
+        there is one, else return None.
+        """
+        if self.is_selected:
+            return self.proxy_model.mapToSource(
+                self.selectionModel().selectedRows()[0]).row()
         else:
             return None
 

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -413,6 +413,10 @@ if __name__ == '__main__':
     model = WatsonTableModel(client)
 
     app = QApplication(sys.argv)
+
+    from PyQt5.QtWidgets import QStyleFactory
+    app.setStyle(QStyleFactory.create('WindowsVista'))
+
     overview_window = WatsonOverviewWidget(client, model)
     overview_window.show()
     app.exec_()

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -158,10 +158,14 @@ class WatsonDailyTableWidget(QFrame):
                 self.scene.removeWidget(self.tables[-1])
                 self.tables[-1].deleteLater()
 
+        # We hide the scrollbar widget while the tables are ubdated
+        # to avoid flickering.
+        self.scrollarea.widget().hide()
         base_span = date_span[0].span('day')
         for i, table in enumerate(self.tables):
             table.set_date_span(
                 (base_span[0].shift(days=i), base_span[1].shift(days=i)))
+        self.scrollarea.widget().show()
 
     def setup_time_total(self, delta_seconds):
         """

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -113,16 +113,16 @@ class WatsonDailyTableWidget(QFrame):
         scrollarea.verticalScrollBar().valueChanged.connect(
             self.srollbar_value_changed)
 
-        self.view = ColoredFrame(color='light')
+        widget = ColoredFrame(color='light')
 
-        self.scene = QVBoxLayout(self.view)
+        self.scene = QVBoxLayout(widget)
         self.scene.addStretch(100)
         self.scene.setSpacing(5)
         self.scene.setContentsMargins(10, 5, 10, 5)
 
         scrollarea.setMinimumWidth(900)
         scrollarea.setMinimumHeight(500)
-        scrollarea.setWidget(self.view)
+        scrollarea.setWidget(widget)
         scrollarea.setWidgetResizable(True)
 
         return scrollarea

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -143,6 +143,7 @@ class WatsonDailyTableWidget(QFrame):
         Set the range over which actitivies are displayed in the widget
         and update the layout accordingly by adding or removing tables.
         """
+        self.date_span = date_span
         total_seconds = round((date_span[1] - date_span[0]).total_seconds())
         ndays = ceil(total_seconds / (60*60*24))
         while True:
@@ -267,6 +268,10 @@ class WatsonTableWidget(QWidget):
         """
         self.timecount.setText(total_seconds_to_hour_min(total_seconds))
 
+    def get_selected_row(self):
+        """Return the index of the selected row in the view."""
+        return self.view.get_selected_row()
+
 
 # ---- TableView
 
@@ -387,6 +392,17 @@ class FormatedWatsonTableView(BasicWatsonTableView):
     def set_selected(self, value):
         self.is_selected = bool(value)
         self.viewport().update()
+
+    def get_selected_row(self):
+        """
+        Return the index of the selected row if there is one, return
+        None otherwise.
+        """
+        if self.is_selected:
+            indexes = self.selectionModel().selectedRows()
+            return indexes[0].row()
+        else:
+            return None
 
     def set_hovered_row(self, row):
         if self._hovered_row != row:

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -23,6 +23,7 @@ from PyQt5.QtWidgets import (
 
 from qwatson.utils import icons
 from qwatson.utils.dates import arrowspan_to_str, total_seconds_to_hour_min
+from qwatson.widgets.layout import ColoredFrame
 from qwatson.models.tablemodels import WatsonSortFilterProxyModel
 from qwatson.models.delegates import (
     ToolButtonDelegate, ComboBoxDelegate, LineEditDelegate, StartDelegate,
@@ -66,8 +67,7 @@ class WatsonDailyTableWidget(QFrame):
         """Setup the scrollarea that holds all the table widgets."""
         scrollarea = QScrollArea()
 
-        self.view = QFrame()
-        self.view.setStyleSheet("QFrame {background-color:white;}")
+        self.view = ColoredFrame(color='light')
 
         self.scene = QVBoxLayout(self.view)
         self.scene.addStretch(100)

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -159,15 +159,13 @@ class WatsonTableWidget(QWidget):
         self.timecount.setMargin(5)
         self.timecount.setFont(font)
 
-        titlebar = QFrame()
-        titlebar.setStyleSheet("QFrame {background-color:gray;}")
+        titlebar = ColoredFrame(color='grey')
+        titlebar_layout = QHBoxLayout(titlebar)
+        titlebar_layout.setContentsMargins(0, 0, 0, 0)
 
-        layout = QGridLayout(titlebar)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setColumnStretch(1, 100)
-
-        layout.addWidget(self.title, 0, 0)
-        layout.addWidget(self.timecount, 0, 2)
+        titlebar_layout.addWidget(self.title)
+        titlebar_layout.addStretch(100)
+        titlebar_layout.addWidget(self.timecount)
 
         return titlebar
 
@@ -207,7 +205,6 @@ class BasicWatsonTableView(QTableView):
         # ---- Setup the delegates
 
         columns = source_model.COLUMNS
-
         self.setItemDelegateForColumn(
             columns['icons'], ToolButtonDelegate(self))
         self.setItemDelegateForColumn(

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -26,10 +26,51 @@ from PyQt5.QtWidgets import (
 from qwatson.utils import icons
 from qwatson.utils.dates import arrowspan_to_str, total_seconds_to_hour_min
 from qwatson.widgets.layout import ColoredFrame
+from qwatson.widgets.dates import DateRangeNavigator
 from qwatson.models.tablemodels import WatsonSortFilterProxyModel
 from qwatson.models.delegates import (
     BaseDelegate, ToolButtonDelegate, ComboBoxDelegate, LineEditDelegate,
     StartDelegate, StopDelegate, TagEditDelegate)
+
+
+class WatsonOverviewWidget(QWidget):
+    """A widget to show and edit activities logged with Watson."""
+    def __init__(self, client, model, parent=None):
+        super(WatsonOverviewWidget, self).__init__(parent)
+        self.setWindowIcon(icons.get_icon('master'))
+        self.setWindowTitle("Activity Overview")
+
+        self.setup(model)
+        self.date_span_changed()
+
+    def setup(self, model):
+        """Setup the widget with the provided arguments."""
+        self.table_widg = WatsonDailyTableWidget(model, parent=self)
+
+        self.date_range_nav = DateRangeNavigator()
+        self.date_range_nav.sig_date_span_changed.connect(
+            self.date_span_changed)
+
+        # ---- Setup the layout
+
+        layout = QGridLayout(self)
+        layout.addWidget(self.date_range_nav)
+        layout.addWidget(self.table_widg)
+
+    def date_span_changed(self):
+        """Handle when the range of the date range navigator widget change."""
+        self.table_widg.set_date_span(self.date_range_nav.current)
+
+    def show(self):
+        """Qt method override."""
+        super(WatsonOverviewWidget, self).show()
+        if self.windowState() & Qt.WindowMaximized:
+            self.setWindowState(Qt.WindowActive | Qt.WindowMaximized)
+        else:
+            self.setWindowState(Qt.WindowActive)
+        self.activateWindow()
+        self.raise_()
+        self.setFocus()
 
 
 # ---- TableWidget

--- a/qwatson/widgets/tests/test_overview.py
+++ b/qwatson/widgets/tests/test_overview.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+# ---- Standard imports
+
+import os
+import os.path as osp
+
+# ---- Third party imports
+
+import pytest
+from PyQt5.QtCore import Qt
+
+# ---- Local imports
+
+from qwatson.mainwindow import QWatson
+from qwatson.utils.dates import local_arrow_from_tuple
+
+
+APPDIR = osp.join(osp.dirname(__file__), 'appdir')
+FRAME_FILE = osp.join(APPDIR, 'frames')
+
+NOW = local_arrow_from_tuple((2018, 6, 14, 23, 59, 0))
+SPAN = NOW.floor('week').span('week')
+
+
+# ---- Fixtures and utilities
+
+@pytest.fixture
+def overview_creator(qtbot, mocker):
+    if not osp.exists(FRAME_FILE):
+        create_framefile(mocker)
+
+    mocker.patch('arrow.now', return_value=NOW)
+
+    qwatson = QWatson(config_dir=APPDIR)
+    overview = qwatson.overview_widg
+    qtbot.addWidget(overview)
+    return overview, qtbot, mocker
+
+
+def create_framefile(mocker):
+    """
+    Create a framefile that span over the current week with one activity
+    every hour.
+    """
+    qwatson = QWatson(APPDIR)
+
+    i = 0
+    while True:
+        start = SPAN[0].shift(hours=i*6)
+        mocker.patch('arrow.now', return_value=start)
+        qwatson.client.start('test_overview')
+        i += 1
+        stop = SPAN[0].shift(hours=i*6)
+        mocker.patch('arrow.now', return_value=stop)
+        qwatson.stop_watson(
+            message='activity #%s' % i, project='test_overview', tags=None,
+            round_to=5)
+
+        if stop >= SPAN[1]:
+            break
+    qwatson.client.save()
+
+
+def test_overview_init(overview_creator):
+    """Test that the overview is initialized correctly."""
+    overview, qtbot, mocker = overview_creator
+    overview.show()
+    qtbot.waitForWindowShown(overview)
+
+    assert overview.isVisible()
+
+    assert overview.table_widg.total_seconds == 7*24*1*60*60
+    assert len(overview.table_widg.tables) == 7
+    assert overview.table_widg.last_focused_table is None
+    assert overview.table_widg.date_span == SPAN
+
+
+def test_overview_row_selection(overview_creator):
+    """
+    Test that table and row selection is working as expected.
+    """
+    overview, qtbot, mocker = overview_creator
+    overview.show()
+    qtbot.waitForWindowShown(overview)
+
+    tables = overview.table_widg.tables
+
+    # Mouse click on the second row of the second table.
+
+    index = tables[1].view.proxy_model.index(1, 0)
+    visual_rect = tables[1].view.visualRect(index)
+
+    qtbot.mouseClick(
+        tables[1].view.viewport(), Qt.LeftButton, pos=visual_rect.center())
+
+    assert overview.table_widg.last_focused_table == tables[1]
+    assert overview.table_widg.last_focused_table.get_selected_row() == 1
+
+    # Mouse click on the third row of the second table.
+
+    index = tables[2].view.proxy_model.index(2, 0)
+    visual_rect = tables[2].view.visualRect(index)
+
+    qtbot.mouseClick(
+        tables[2].view.viewport(), Qt.LeftButton, pos=visual_rect.center())
+
+    assert overview.table_widg.last_focused_table == tables[2]
+    assert tables[2].get_selected_row() == 2
+
+    # Assert that all tables but 2 have no selected row
+
+    for table in tables:
+        if table != overview.table_widg.last_focused_table:
+            assert table.get_selected_row() is None
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])

--- a/qwatson/widgets/tests/test_overview.py
+++ b/qwatson/widgets/tests/test_overview.py
@@ -46,18 +46,19 @@ def overview_creator(qtbot, mocker):
 
 def create_framefile(mocker):
     """
-    Create a framefile that span over the current week with one activity
-    every hour.
+    Create a framefile that span over the current week with 2 activity of
+    6 hours per day, between 6:00 AM and 12:00 PM and 6:00PM and 12:00AM.
     """
     qwatson = QWatson(APPDIR)
 
-    i = 0
+    i = 1
     while True:
         start = SPAN[0].shift(hours=i*6)
         mocker.patch('arrow.now', return_value=start)
         qwatson.client.start('test_overview')
-        i += 1
-        stop = SPAN[0].shift(hours=i*6)
+
+        stop = SPAN[0].shift(hours=(i+1)*6)
+        stop = SPAN[0].shift(hours=(i+1)*6)
         mocker.patch('arrow.now', return_value=stop)
         qwatson.stop_watson(
             message='activity #%s' % i, project='test_overview', tags=None,
@@ -65,6 +66,8 @@ def create_framefile(mocker):
 
         if stop >= SPAN[1]:
             break
+        i += 2
+
     qwatson.client.save()
 
 
@@ -76,7 +79,7 @@ def test_overview_init(overview_creator):
 
     assert overview.isVisible()
 
-    assert overview.table_widg.total_seconds == 7*24*1*60*60
+    assert overview.table_widg.total_seconds == 7*(2*6)*60*60
     assert len(overview.table_widg.tables) == 7
     assert overview.table_widg.last_focused_table is None
     assert overview.table_widg.date_span == SPAN
@@ -100,10 +103,17 @@ def test_overview_row_selection(overview_creator):
     qtbot.mouseClick(
         tables[1].view.viewport(), Qt.LeftButton, pos=visual_rect.center())
 
+    # Assert that all but one table have a row and a frame selected.
     assert overview.table_widg.last_focused_table == tables[1]
-    assert overview.table_widg.last_focused_table.get_selected_row() == 1
+    for table in tables:
+        if table != overview.table_widg.last_focused_table:
+            assert table.get_selected_row() is None
+            assert table.get_selected_frame_index() is None
+        else:
+            assert table.get_selected_row() == 1
+            assert table.get_selected_frame_index() == 2 + 2 - 1
 
-    # Mouse click on the third row of the second table.
+    # Mouse click on the first row of the second table.
 
     index = tables[2].view.proxy_model.index(2, 0)
     visual_rect = tables[2].view.visualRect(index)
@@ -112,13 +122,16 @@ def test_overview_row_selection(overview_creator):
         tables[2].view.viewport(), Qt.LeftButton, pos=visual_rect.center())
 
     assert overview.table_widg.last_focused_table == tables[2]
-    assert tables[2].get_selected_row() == 2
 
-    # Assert that all tables but 2 have no selected row
+    # Assert that all tables but 2 have no selected row and frame.
 
     for table in tables:
         if table != overview.table_widg.last_focused_table:
             assert table.get_selected_row() is None
+            assert table.get_selected_frame_index() is None
+        else:
+            assert table.get_selected_row() == 0
+            assert table.get_selected_frame_index() == 2 + 2 + 1 - 1
 
 
 if __name__ == "__main__":

--- a/qwatson/widgets/tests/test_overview.py
+++ b/qwatson/widgets/tests/test_overview.py
@@ -134,5 +134,39 @@ def test_overview_row_selection(overview_creator):
             assert table.get_selected_frame_index() == 2 + 2 + 1 - 1
 
 
+def test_mouse_hovered_row(overview_creator):
+    """
+    Test that the highlighting of mouse hovered row is working as expected.
+    """
+    overview, qtbot, mocker = overview_creator
+    overview.show()
+    qtbot.waitForWindowShown(overview)
+
+    tables = overview.table_widg.tables
+
+    # Mouse hover the second row of the second table.
+
+    index = tables[1].view.proxy_model.index(1, 0)
+    visual_rect = tables[1].view.visualRect(index)
+
+    qtbot.mouseMove(tables[1].view.viewport(), pos=visual_rect.center())
+    tables[1].view.itemEnterEvent(index)
+    assert tables[1].view._hovered_row == 1
+
+    # Mouse hover the first row of the fourth table and simulate a change of
+    # value of the scrollbar. Assert that the _hovered_row of the second
+    # table is now None and that the  _hovered_row of the fourth table is 0.
+
+    index = tables[4].view.proxy_model.index(0, 0)
+    visual_rect = tables[4].view.visualRect(index)
+
+    qtbot.mouseMove(tables[4].view.viewport(), pos=visual_rect.center())
+    overview.table_widg.srollbar_value_changed(
+        overview.table_widg.scrollarea.verticalScrollBar().value())
+
+    assert tables[1].view._hovered_row is None
+    assert tables[4].view._hovered_row == 0
+
+
 if __name__ == "__main__":
     pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])


### PR DESCRIPTION
This is a step towards implementing  #49. Before we could start working on implementing the feature in #49, we need a mean from the GUI to select rows first. This was not an easy task because the overview table is composed of multiple table view. We had to add some mechanics so that the highlighting and selection was done as if it was one table view.

- Use the style from `QListView` to paint the items in the `QTableView`. The `QListView` uses the areo theme in Windows 10. This looks better and give a more polish and unified look to the table in Windows.
- Added some utility function to manage colors and palette.
- The new `BaseDelegate` class should help a lot in the future to customize the look of the table.

This is how this look with the `WindowsVista` theme in Windows 10 :
![row_highlight_selection](https://user-images.githubusercontent.com/10170372/42242002-8072ec8c-7eda-11e8-9196-1b0a2d109571.gif)

This is how this look with the `Fusion` theme in Windows 10 :
![row_highlight_selection_fusion](https://user-images.githubusercontent.com/10170372/42242767-0dbbadb6-7edd-11e8-8563-5b7864e8cfbd.gif)
