### PR TITLE
PR: Fix a bug when 'start from last' time is later than now.

### DIFF
--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -14,6 +14,7 @@ import platform
 # ---- Third parties imports
 
 import click
+import arrow
 from PyQt5.QtCore import Qt, QModelIndex
 from PyQt5.QtWidgets import (QApplication, QGridLayout, QHBoxLayout,
                              QSizePolicy, QWidget, QStackedWidget,
@@ -280,7 +281,7 @@ class QWatson(QWidget, QWatsonImportMixin):
             if start_from == 'now':
                 self.start_watson()
             elif start_from == 'last' and len(frames) > 0:
-                self.start_watson(start_time=frames[-1].stop)
+                self.start_watson(min(frames[-1].stop, arrow.now()))
             else:
                 self.datetime_input_dial.show()
         else:

--- a/qwatson/tests/test_mainwindow.py
+++ b/qwatson/tests/test_mainwindow.py
@@ -202,7 +202,7 @@ def test_start_from_last_when_later_than_now(qtbot, mocker):
     """
     Test that starting a new activity with the option 'start from' set to
     'last' is working as expected when the stop time of the last saved
-    activity is later than current time (See Issue #53).
+    activity is later than current time (See Issue #53 and PR #54).
     """
     now = local_arrow_from_tuple((2018, 6, 14, 17, 13, 43))
     mocker.patch('arrow.now', return_value=now)

--- a/qwatson/tests/test_mainwindow.py
+++ b/qwatson/tests/test_mainwindow.py
@@ -198,6 +198,41 @@ def test_rename_project(qtbot, mocker):
     mainwindow.close()
 
 
+def test_start_from_last_when_later_than_now(qtbot, mocker):
+    """
+    Test that starting a new activity with the option 'start from' set to
+    'last' is working as expected when the stop time of the last saved
+    activity is later than current time (See Issue #53).
+    """
+    now = local_arrow_from_tuple((2018, 6, 14, 17, 13, 43))
+    mocker.patch('arrow.now', return_value=now)
+    mocker.patch('time.time', return_value=now.timestamp)
+
+    mainwindow = QWatson(APPDIR)
+    qtbot.addWidget(mainwindow)
+    mainwindow.show()
+
+    mainwindow.start_from.setCurrentIndex(1)
+    assert mainwindow.start_from.text() == 'start from last'
+
+    assert now == mainwindow.client.frames[-1].stop
+
+    # Start the activity
+
+    qtbot.mouseClick(mainwindow.btn_startstop, Qt.LeftButton)
+    assert mainwindow.elap_timer.is_started
+    assert round(mainwindow.elap_timer._elapsed_time) == 0
+
+    # Stop the activity
+
+    qtbot.mouseClick(mainwindow.btn_startstop, Qt.LeftButton)
+    assert not mainwindow.elap_timer.is_started
+
+    frame = mainwindow.client.frames[-1]
+    assert frame.start.format('YYYY-MM-DD HH:mm') == '2018-06-14 17:15'
+    assert frame.stop.format('YYYY-MM-DD HH:mm') == '2018-06-14 17:15'
+
+
 def test_start_from_last(qtbot, mocker):
     """
     Test that starting an activity with the option 'start from' set to 'last'
@@ -479,8 +514,8 @@ def test_accept_import_from_watson_cancel(qtbot, mocker):
     assert mainwindow.currentIndex() == 0
 
     table = mainwindow.overview_widg.table_widg.tables[3]
-    assert len(mainwindow.client.frames) == 4
-    assert table.view.proxy_model.get_accepted_row_count() == 4
+    assert len(mainwindow.client.frames) == 5
+    assert table.view.proxy_model.get_accepted_row_count() == 5
 
     assert mainwindow.activity_input_dial.project == 'project1_renamed'
     assert mainwindow.activity_input_dial.comment == 'First activity'

--- a/qwatson/tests/test_mainwindow.py
+++ b/qwatson/tests/test_mainwindow.py
@@ -215,8 +215,6 @@ def test_start_from_last_when_later_than_now(qtbot, mocker):
     mainwindow.start_from.setCurrentIndex(1)
     assert mainwindow.start_from.text() == 'start from last'
 
-    assert now == mainwindow.client.frames[-1].stop
-
     # Start the activity
 
     qtbot.mouseClick(mainwindow.btn_startstop, Qt.LeftButton)

--- a/qwatson/widgets/clock.py
+++ b/qwatson/widgets/clock.py
@@ -10,6 +10,7 @@
 
 import time
 import sys
+import arrow
 
 # ---- Third party imports
 
@@ -37,6 +38,7 @@ class ElapsedTimeLCDNumber(QLCDNumber):
     def start(self, start_time=None):
         """Start the elapsed time counter."""
         self._start_time = time.time() if start_time is None else start_time
+        self.update_elapsed_time()
         self.timer.start(10)
         self.is_started = True
 
@@ -47,12 +49,14 @@ class ElapsedTimeLCDNumber(QLCDNumber):
 
     def update_elapsed_time(self):
         """Update elapsed time in the widget."""
-        elapsed_time = time.time() - self._start_time
-        self.display(time.strftime("%H:%M:%S", time.gmtime(elapsed_time)))
+        self._elapsed_time = time.time() - self._start_time
+        self.display(
+            time.strftime("%H:%M:%S", time.gmtime(self._elapsed_time)))
 
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     timer = ElapsedTimeLCDNumber()
     timer.show()
+    timer.start(arrow.now().timestamp)
     app.exec_()

--- a/qwatson/widgets/clock.py
+++ b/qwatson/widgets/clock.py
@@ -10,7 +10,6 @@
 
 import time
 import sys
-import arrow
 
 # ---- Third party imports
 
@@ -58,5 +57,5 @@ if __name__ == '__main__':
     app = QApplication(sys.argv)
     timer = ElapsedTimeLCDNumber()
     timer.show()
-    timer.start(arrow.now().timestamp)
+    timer.start()
     app.exec_()


### PR DESCRIPTION
Fixes #53

- [x] Add a ci-test to catch the bug.
- [x] Fix the bug by passing the minimum between the stop time of the last activity and the now time to the elapse timer.