### PR TITLE
PR: Format the dialog to confirm the deletion of a project and related activities

### DIFF
--- a/qwatson/dialogs/__init__.py
+++ b/qwatson/dialogs/__init__.py
@@ -12,3 +12,4 @@ route user commands to Watson.
 from .importdialog import ImportDialog
 from .datetimedialog import DateTimeInputDialog
 from .closedialog import CloseDialog
+from .delprojectdialog import DelProjectDialog

--- a/qwatson/dialogs/delprojectdialog.py
+++ b/qwatson/dialogs/delprojectdialog.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+# ---- Standard imports
+
+import sys
+
+# ---- Third party imports
+
+from PyQt5.QtWidgets import (QApplication, QVBoxLayout, QPushButton)
+
+# ---- Local imports
+
+from qwatson.dialogs.basedialog import BaseDialog
+from qwatson.widgets.layout import InfoBox
+
+
+class DelProjectDialog(BaseDialog):
+    """
+    A dialog to ask the user to confirm that he truly wants to delete the
+    project and all related frames.
+    The QWatson main is actually in charge of deleting the project.
+    """
+
+    def __init__(self, main=None, parent=None):
+        super(DelProjectDialog, self).__init__(main, parent)
+
+    # ---- Setup layout
+
+    def setup(self):
+        """Setup the dialog widgets and layout."""
+
+        # Add buttons to the dialog
+
+        self.add_dialog_button(QPushButton('Ok'), 'Ok')
+        self.add_dialog_button(QPushButton('Cancel'), 'Cancel', True)
+
+        # Setup the info box
+
+        self.info_box = InfoBox('', 'warning', 'messagebox')
+        self.info_box.setContentsMargins(10, 10, 10, 10)
+
+        # Setup the layout of the dialog
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        layout.addWidget(self.info_box)
+        layout.addWidget(self.button_box)
+        layout.setStretch(0, 100)
+
+    def show(self, project, nbr_of_activities):
+        """
+        Extend show method to update the text of the info box with the
+        provided arguments.
+        """
+        self.project = project
+
+        text = "<b>"
+        text += ("All activities that are not in a project "
+                 if project == '' else
+                 "The project \"%s\" and all related activities " % project)
+        text += "will be permanently erased from the database.</b><br><br>"
+        text += "%d " % nbr_of_activities
+        text += 'activity' if nbr_of_activities <= 1 else 'activities'
+        text += " will be deleted by this action."
+        self.info_box.setText(text)
+
+        super(DelProjectDialog, self).show()
+
+    def receive_answer(self, answer):
+        """
+        Handle when an answer has been provided to the dialog by the user.
+        """
+        if self.main is not None:
+            if answer == 'Ok':
+                self.main.del_project(self.project)
+            elif answer == 'Cancel':
+                pass
+            self.main.setCurrentIndex(0)
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    del_proj_dialog = DelProjectDialog()
+    del_proj_dialog.show('', 24)
+    del_proj_dialog2 = DelProjectDialog()
+    del_proj_dialog2.show('Some project', 35)
+    app.exec_()

--- a/qwatson/utils/icons.py
+++ b/qwatson/utils/icons.py
@@ -52,12 +52,15 @@ def get_iconsize(size):
 
 
 def get_standard_icon(constant):
-    """Return a QIcon of a standard pixmap."""
+    """
+    Return a QIcon of a standard pixmap.
+
+    The value of the 'constant' must be either 'question', 'information',
+    'warning', or 'critical'.
+    """
+    constant = getattr(QStyle, 'SP_MessageBox' + constant.title())
     style = QApplication.instance().style()
-    if constant == 'question':
-        return style.standardIcon(QStyle.SP_MessageBoxQuestion)
-    if constant == 'information':
-        return style.standardIcon(QStyle.SP_MessageBoxInformation)
+    return style.standardIcon(constant)
 
 
 def get_standard_iconsize(constant):

--- a/qwatson/watson_ext/watsonhelpers.py
+++ b/qwatson/watson_ext/watsonhelpers.py
@@ -44,6 +44,11 @@ def edit_frame_at(client, index, start=None, stop=None, project=None,
         project, start, stop, tags, frame.id, updated_at, message]
 
 
+def get_frame_nbr_for_project(client, project):
+    """Return the number of activities associated with a given project."""
+    return len(list(client.frames.filter(projects=[project])))
+
+
 def round_frame_at(client, index, base):
     """Round the start and stop time of the Watson frame at index."""
     frame = client.frames[index]

--- a/qwatson/widgets/layout.py
+++ b/qwatson/widgets/layout.py
@@ -96,7 +96,7 @@ class InfoBox(ColoredFrame):
 
         # Setup the layout for the text.
 
-        info_label = QLabel(info_text)
+        self.info_label = info_label = QLabel(info_text)
         info_label.setAlignment(Qt.AlignTop | Qt.AlignLeft)
         info_label.setWordWrap(True)
         info_label.setOpenExternalLinks(True)
@@ -118,6 +118,10 @@ class InfoBox(ColoredFrame):
 
         layout.setRowStretch(1, 100)
         layout.setColumnStretch(1, 100)
+
+    def setText(self, text):
+        """Set the text of the info box to the specified text."""
+        self.info_label.setText(text)
 
     def setSpacing(self, x):
         """Set the spacing between the icon and the text."""

--- a/qwatson/widgets/projects.py
+++ b/qwatson/widgets/projects.py
@@ -92,7 +92,7 @@ class ProjectManager(QWidget):
         self.btn_remove.clicked.connect(self.btn_remove_isclicked)
         self.btn_remove.setToolTip(
             "<b>Delete Project</b><br><br>"
-            "Erase permanently the current project and all related"
+            "Erase permanently the currently selected project and all related"
             " activities.<br><br>"
             "If no project is selected, erase all activities"
             " that are currently not in a project.")

--- a/qwatson/widgets/projects.py
+++ b/qwatson/widgets/projects.py
@@ -75,15 +75,27 @@ class ProjectManager(QWidget):
 
         self.btn_add = QToolButtonSmall('plus')
         self.btn_add.clicked.connect(self.project_cbox.add_project)
-        self.btn_add.setToolTip("Add a new project")
+        self.btn_add.setToolTip(
+            "<b>Add Project</b><br><br>"
+            "Add a new project to the list of availables projects.")
 
         self.btn_rename = QToolButtonSmall('edit')
         self.btn_rename.clicked.connect(self.project_cbox.rename_project)
-        self.btn_rename.setToolTip("Rename the current project")
+        self.btn_rename.setToolTip(
+            "<b>Rename Project</b><br><br>"
+            "Rename the currently selected project and update the project of"
+            " all related activities.<br><br>"
+            "If no project is selected when renaming, set the project of all"
+            " activities that are currently not in a project.")
 
         self.btn_remove = QToolButtonSmall('clear')
         self.btn_remove.clicked.connect(self.btn_remove_isclicked)
-        self.btn_remove.setToolTip("Delete the current project")
+        self.btn_remove.setToolTip(
+            "<b>Delete Project</b><br><br>"
+            "Erase permanently the current project and all related"
+            " activities.<br><br>"
+            "If no project is selected, erase all activities"
+            " that are currently not in a project.")
 
         for item in [self.btn_add, self.btn_rename, self.btn_remove]:
             toolbar.addWidget(item)


### PR DESCRIPTION
Currently, when clicking to delete a project, an external dialog pops up that ask the user if they really want to delete the project and all related frames. Here is a screenshot that show how it looks before this PR:

![image](https://user-images.githubusercontent.com/10170372/43242766-e358aefc-9070-11e8-8b04-275a07b7a379.png)

This PR use the structure we've put in place to create dialogs that are embedded within the mainwindow. We've also improved the text to make it clearer.

Here is a screenshot when the project is not `''`:
![image](https://user-images.githubusercontent.com/10170372/43242674-7560e95a-9070-11e8-8143-0d4541a409ae.png)

Here is a screenshot of the dialog when the project is `''`:
![image](https://user-images.githubusercontent.com/10170372/43242730-b6c458fa-9070-11e8-979c-d1c2e572ab28.png)

