### PR TITLE
PR: Add a dialog to ask user confirmation before merging the activities of two project that are not empty when renaming

### DIFF
--- a/qwatson/dialogs/__init__.py
+++ b/qwatson/dialogs/__init__.py
@@ -13,3 +13,4 @@ from .importdialog import ImportDialog
 from .datetimedialog import DateTimeInputDialog
 from .closedialog import CloseDialog
 from .delprojectdialog import DelProjectDialog
+from .mergeproject import MergeProjectDialog

--- a/qwatson/dialogs/delprojectdialog.py
+++ b/qwatson/dialogs/delprojectdialog.py
@@ -90,8 +90,10 @@ class DelProjectDialog(BaseDialog):
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
-    del_proj_dialog = DelProjectDialog()
-    del_proj_dialog.show('', 24)
-    del_proj_dialog2 = DelProjectDialog()
-    del_proj_dialog2.show('Some project', 35)
+    d1 = DelProjectDialog()
+    d1.show('', 24)
+    d1.setFixedSize(300, 162)
+    d2 = DelProjectDialog()
+    d2.show('x', 35)
+    d2.setFixedSize(300, 162)
     app.exec_()

--- a/qwatson/dialogs/delprojectdialog.py
+++ b/qwatson/dialogs/delprojectdialog.py
@@ -80,7 +80,7 @@ class DelProjectDialog(BaseDialog):
         """
         if self.main is not None:
             if answer == 'Ok':
-                self.main.del_project(self.project)
+                self.main.del_project(self.project, force=True)
             elif answer == 'Cancel':
                 pass
             self.main.setCurrentIndex(0)

--- a/qwatson/dialogs/delprojectdialog.py
+++ b/qwatson/dialogs/delprojectdialog.py
@@ -55,7 +55,7 @@ class DelProjectDialog(BaseDialog):
         layout.addWidget(self.button_box)
         layout.setStretch(0, 100)
 
-    def show(self, project, nbr_of_activities):
+    def show(self, project, na):
         """
         Extend show method to update the text of the info box with the
         provided arguments.
@@ -67,9 +67,11 @@ class DelProjectDialog(BaseDialog):
                  if project == '' else
                  "The project \"%s\" and all related activities " % project)
         text += "will be permanently erased from the database.</b><br><br>"
-        text += "%d " % nbr_of_activities
-        text += 'activity' if nbr_of_activities <= 1 else 'activities'
-        text += " will be deleted by this action."
+        text += "%d " % na
+        text += 'activity is' if na <= 1 else 'activities are'
+        text += (" not currently in a project" if project == '' else
+                 " currently in project \"%s\"" % project)
+        text += "."
         self.info_box.setText(text)
 
         super(DelProjectDialog, self).show()

--- a/qwatson/dialogs/mergeproject.py
+++ b/qwatson/dialogs/mergeproject.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2018 Jean-Sébastien Gosselin
+# https://github.com/jnsebgosselin/qwatson
+#
+# This file is part of QWatson.
+# Licensed under the terms of the GNU General Public License.
+
+# ---- Standard imports
+
+import sys
+
+# ---- Third party imports
+
+from PyQt5.QtWidgets import (QApplication, QVBoxLayout, QPushButton)
+
+# ---- Local imports
+
+from qwatson.dialogs.basedialog import BaseDialog
+from qwatson.widgets.layout import InfoBox
+
+
+class MergeProjectDialog(BaseDialog):
+    """
+    A dialog to ask the user to confirm that he truly wants to merge project
+    x with project y.
+    The QWatson main window is actually in charge of deleting the project.
+    """
+
+    def __init__(self, main=None, parent=None):
+        super(MergeProjectDialog, self).__init__(main, parent)
+
+    # ---- Setup layout
+
+    def setup(self):
+        """Setup the dialog widgets and layout."""
+
+        # Add buttons to the dialog
+
+        self.add_dialog_button(QPushButton('Ok'), 'Ok')
+        self.add_dialog_button(QPushButton('Cancel'), 'Cancel', True)
+
+        # Setup the info box
+
+        self.info_box = InfoBox('', 'warning', 'messagebox')
+        self.info_box.setContentsMargins(10, 10, 10, 10)
+
+        # Setup the layout of the dialog
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        layout.addWidget(self.info_box)
+        layout.addWidget(self.button_box)
+        layout.setStretch(0, 100)
+
+    def show(self, proj1, na1, proj2, na2):
+        """
+        Extend show method to update the text of the info box with the
+        provided arguments.
+        """
+        self.proj1, self.proj2 = proj1, proj2
+
+        text = "<b>All activities "
+        text += ("that are not currently in a project" if proj1 == '' else
+                 "of project \"%s\"" % proj1)
+        text += " will be permanently merged "
+        text += ("with those that are not currently in a project"
+                 if proj2 == '' else
+                 "with those of project \"%s\"" % proj2)
+        text += ".</b><br><br>"
+        text += "%d " % na1
+        text += 'activity is' if na1 <= 1 else 'activities are'
+        text += (" not currently in a project" if proj1 == '' else
+                 " currently in project \"%s\"" % proj1)
+        text += ".<br>"
+        text += "%d " % na2
+        text += 'activity is' if na2 <= 1 else 'activities are'
+        text += (" not currently in a project" if proj2 == '' else
+                 " currently in project \"%s\"" % proj2)
+        text += "."
+
+        self.info_box.setText(text)
+
+        super(MergeProjectDialog, self).show()
+
+    def receive_answer(self, answer):
+        """
+        Handle when an answer has been provided to the dialog by the user.
+        """
+        if self.main is not None:
+            if answer == 'Ok':
+                self.main.del_project(self.project)
+            elif answer == 'Cancel':
+                pass
+            self.main.setCurrentIndex(0)
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    d1 = MergeProjectDialog()
+    d1.show('', 3, 'projectx', 24)
+    d2 = MergeProjectDialog()
+    d2.show('projectx', 1, 'projecty', 4)
+    d3 = MergeProjectDialog()
+    d3.show('projectx', 27, '', 4)
+    app.exec_()

--- a/qwatson/dialogs/mergeproject.py
+++ b/qwatson/dialogs/mergeproject.py
@@ -98,10 +98,17 @@ class MergeProjectDialog(BaseDialog):
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
+
     d1 = MergeProjectDialog()
     d1.show('', 3, 'x', 24)
+    d1.setFixedSize(300, 162)
+
     d2 = MergeProjectDialog()
     d2.show('x', 1, 'y', 4)
+    d2.setFixedSize(300, 162)
+
     d3 = MergeProjectDialog()
     d3.show('x', 27, '', 4)
+    d3.setFixedSize(300, 162)
+
     app.exec_()

--- a/qwatson/dialogs/mergeproject.py
+++ b/qwatson/dialogs/mergeproject.py
@@ -74,13 +74,12 @@ class MergeProjectDialog(BaseDialog):
         text += 'activity is' if na1 <= 1 else 'activities are'
         text += (" not currently in a project" if proj1 == '' else
                  " currently in project \"%s\"" % proj1)
-        text += ".<br>"
+        text += " and "
         text += "%d " % na2
         text += 'activity is' if na2 <= 1 else 'activities are'
         text += (" not currently in a project" if proj2 == '' else
                  " currently in project \"%s\"" % proj2)
         text += "."
-
         self.info_box.setText(text)
 
         super(MergeProjectDialog, self).show()
@@ -91,7 +90,7 @@ class MergeProjectDialog(BaseDialog):
         """
         if self.main is not None:
             if answer == 'Ok':
-                self.main.del_project(self.project)
+                self.main.rename_project(self.proj1, self.proj2, force=True)
             elif answer == 'Cancel':
                 pass
             self.main.setCurrentIndex(0)
@@ -100,9 +99,9 @@ class MergeProjectDialog(BaseDialog):
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     d1 = MergeProjectDialog()
-    d1.show('', 3, 'projectx', 24)
+    d1.show('', 3, 'x', 24)
     d2 = MergeProjectDialog()
-    d2.show('projectx', 1, 'projecty', 4)
+    d2.show('x', 1, 'y', 4)
     d3 = MergeProjectDialog()
-    d3.show('projectx', 27, '', 4)
+    d3.show('x', 27, '', 4)
     app.exec_()

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -59,7 +59,7 @@ class QWatsonProjectMixin(object):
 
         self.project_manager.sig_rename_project.connect(self.rename_project)
         self.project_manager.sig_add_project.connect(self.add_new_project)
-        self.project_manager.sig_del_project.connect(self.ask_to_del_project)
+        self.project_manager.sig_del_project.connect(self.del_project)
         self.project_manager.sig_project_changed.connect(self.project_changed)
 
         return self.project_manager
@@ -103,19 +103,18 @@ class QWatsonProjectMixin(object):
             self.project_manager.model.endResetModel()
         self.project_manager.setCurrentProject(project)
 
-    def ask_to_del_project(self, project):
-        """
-        Ask confirmation to the user before deleting the specified project.
-        """
-        self.del_project_dialog.show(
-            project, get_frame_nbr_for_project(self.client, project))
-
-    def del_project(self, project):
+    def del_project(self, project, force=False):
         """
         Ask for confirmation to delete the corresponding project from the
         database and update the model.
+
+        If force is False, a dialog will ask the user before deleting the
+        project.
         """
-        if project in self.client.projects:
+        if force is False:
+            self.del_project_dialog.show(
+                project, get_frame_nbr_for_project(self.client, project))
+        elif force is True and project in self.client.projects:
             index = self.project_manager.currentProjectIndex()
 
             self.model.beginResetModel()

--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -22,7 +22,7 @@ import arrow
 from PyQt5.QtCore import Qt, QModelIndex
 from PyQt5.QtWidgets import (QApplication, QGridLayout, QHBoxLayout,
                              QLabel, QLineEdit, QSizePolicy, QWidget,
-                             QStackedWidget, QVBoxLayout, QMessageBox)
+                             QStackedWidget, QVBoxLayout)
 
 # ---- Local imports
 
@@ -39,7 +39,7 @@ from qwatson.widgets.toolbar import (
 from qwatson import __namever__
 from qwatson.models.tablemodels import WatsonTableModel
 from qwatson.dialogs import (ImportDialog, DateTimeInputDialog, CloseDialog,
-                             DelProjectDialog)
+                             DelProjectDialog, MergeProjectDialog)
 from qwatson.widgets.layout import ColoredFrame
 
 ROUNDMIN = {'round to 1min': 1, 'round to 5min': 5, 'round to 10min': 10}
@@ -71,6 +71,13 @@ class QWatsonProjectMixin(object):
         """
         self.del_project_dialog = DelProjectDialog(main=self, parent=self)
 
+    def setup_merge_project_dialog(self):
+        """
+        Setup the dialog to ask the user confirmation before merging a
+        project with another.
+        """
+        self.merge_project_dialog = MergeProjectDialog(main=self, parent=self)
+
     def currentProject(self):
         """Return the currently selected project in the project manager."""
         return self.project_manager.currentProject()
@@ -85,15 +92,34 @@ class QWatsonProjectMixin(object):
         """Handle when the project selection change in the manager."""
         self.btn_startstop.setEnabled(index != -1)
 
-    def rename_project(self, old_name, new_name):
-        """Rename the project with the new provided name."""
-        if old_name != new_name and old_name in self.client.projects:
+    def rename_project(self, old_name, new_name, force=False):
+        """
+        Rename the project with the new provided name. An error will be
+        raised if 'old_name' is not in the list of Watson.project.
+        """
+        if old_name == new_name:
+            self.project_manager.setCurrentProject(new_name)
+            return
+
+        if force is True:
             self.model.beginResetModel()
             self.project_manager.model.beginResetModel()
             self.client.rename_project(old_name, new_name)
             self.model.endResetModel()
             self.project_manager.model.endResetModel()
-        self.project_manager.setCurrentProject(new_name)
+            self.project_manager.setCurrentProject(new_name)
+        elif force is False:
+            na_old = get_frame_nbr_for_project(self.client, old_name)
+            na_new = get_frame_nbr_for_project(self.client, new_name)
+            if na_old > 0 and na_new > 0:
+                # Since the project 'old_name' is not empty and the project
+                # 'new_name' already exists and is not empty, we ask the
+                # the user confirmation before merging all activities
+                # of project 'old_name' with those of project 'new_name'.
+                self.merge_project_dialog.show(
+                    old_name, na_old, new_name, na_new)
+            else:
+                self.rename_project(old_name, new_name, force=True)
 
     def add_new_project(self, project):
         """Add the new project to the database."""
@@ -261,6 +287,7 @@ class QWatson(QWidget, QWatsonImportMixin, QWatsonProjectMixin,
         self.setup_close_dialog()
         self.setup_import_dialog()
         self.setup_del_project_dialog()
+        self.setup_merge_project_dialog()
 
         # Setup the main layout of the widget
 

--- a/qwatson/tests/test_mainwindow.py
+++ b/qwatson/tests/test_mainwindow.py
@@ -27,7 +27,7 @@ from qwatson.models.delegates import (
     ToolButtonDelegate, TagEditDelegate, LineEditDelegate)
 
 
-APPDIR = osp.join(osp.dirname(__file__), 'appdir')
+APPDIR = osp.join(osp.dirname(__file__), 'appdir1')
 APPDIR2 = osp.join(osp.dirname(__file__), 'appdir2')
 
 


### PR DESCRIPTION
When renaming a non-empty project to a new name corresponding to that of another existing non-empty project in the database, the activities of both projects are merged together.

This is a dangerous operation because it is irreversible and permanent, so a confirmation dialog was definitively needed here.

A confirmation is also requested when the merge is involving the activities that have no project (i.e. that the project is `''`).

Here are some screenshots of how it looks depending of what is merged with what:

![image](https://user-images.githubusercontent.com/10170372/43268091-b83a9ae4-90bd-11e8-9982-cdc508e62cfa.png)

The text for the delete project confirmation dialog was also slightly changed to reflect the format used for the merge project dialog :

![image](https://user-images.githubusercontent.com/10170372/43268465-bd4c015c-90be-11e8-980c-76c7e54b1580.png)