### PR TITLE
PR: Workaround to restore a maximized window correctly after a close

### DIFF
--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -109,8 +109,13 @@ class ActivityOverviewWidget(QWidget):
             (self.windowState() & ~(Qt.WindowMinimized | Qt.WindowFullScreen))
             | Qt.WindowActive)
         self.setAttribute(Qt.WA_Resized, True)
-        super(ActivityOverviewWidget, self).show()
+        # Setting the Qt.WA_Resized attribute to True is required or else the
+        # size of the wigdet will not be updated correctly when restoring the
+        # window from a maximized state and the layout won't be expanded
+        # correctly to the full size of the widget.
+        # See Issue #58 and PR #67.
 
+        super(ActivityOverviewWidget, self).show()
         self.raise_()
         self.setFocus()
 

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -104,13 +104,13 @@ class ActivityOverviewWidget(QWidget):
         self.table_widg.set_date_span(self.date_range_nav.current)
 
     def show(self):
-        """Qt method override."""
+        """Qt method override to restore the window when minimized."""
+        self.setWindowState(
+            (self.windowState() & ~(Qt.WindowMinimized | Qt.WindowFullScreen))
+            | Qt.WindowActive)
+        self.setAttribute(Qt.WA_Resized, True)
         super(ActivityOverviewWidget, self).show()
-        if self.windowState() & Qt.WindowMaximized:
-            self.setWindowState(Qt.WindowActive | Qt.WindowMaximized)
-        else:
-            self.setWindowState(Qt.WindowActive)
-        self.activateWindow()
+
         self.raise_()
         self.setFocus()
 


### PR DESCRIPTION
Fixes #58

This seems like a bug in Qt:
https://stackoverflow.com/questions/49097794/reshowing-maximized-qwidget

As a workaround, we `setAttribute(Qt.WA_Resized, True)` before calling `show` so that the geometry is properly updated when the window was closed maximized.