### PR TITLE
PR: Change the icon of the delete project

### DIFF
--- a/qwatson/widgets/projects.py
+++ b/qwatson/widgets/projects.py
@@ -97,7 +97,7 @@ class ProjectManager(QWidget):
             "If no project is selected, erase all activities"
             " that are currently not in a project.")
 
-        for item in [self.btn_add, self.btn_rename, self.btn_remove]:
+        for item in [self.btn_add, self.btn_remove, self.btn_rename]:
             toolbar.addWidget(item)
 
         return toolbar

--- a/qwatson/widgets/projects.py
+++ b/qwatson/widgets/projects.py
@@ -85,8 +85,12 @@ class ProjectManager(QWidget):
             "<b>Rename Project</b><br><br>"
             "Rename the currently selected project and update the project of"
             " all related activities.<br><br>"
+            "If the new name matches that of an already existing project,"
+            " merge the activities of both project toghether.<br><br>"
             "If no project is selected when renaming, set the project of all"
-            " activities that are currently not in a project.")
+            " activities that are not currently in a project or merge them"
+            " with those of an already existing project if applicable."
+            )
 
         self.btn_remove = QToolButtonSmall('minus')
         self.btn_remove.clicked.connect(self.btn_remove_isclicked)

--- a/qwatson/widgets/projects.py
+++ b/qwatson/widgets/projects.py
@@ -88,7 +88,7 @@ class ProjectManager(QWidget):
             "If no project is selected when renaming, set the project of all"
             " activities that are currently not in a project.")
 
-        self.btn_remove = QToolButtonSmall('clear')
+        self.btn_remove = QToolButtonSmall('minus')
         self.btn_remove.clicked.connect(self.btn_remove_isclicked)
         self.btn_remove.setToolTip(
             "<b>Delete Project</b><br><br>"


### PR DESCRIPTION
- Change the icon from a 'X' to a '-' sign.
- Rework the tooltip of the `Rename project` button to includes cases when projects are merged.

![image](https://user-images.githubusercontent.com/10170372/43537837-69afde86-958e-11e8-986e-66be11006279.png)

![image](https://user-images.githubusercontent.com/10170372/43537962-b809bc78-958e-11e8-8735-014348ac70b0.png)

