### PR TITLE
PR: Refactoring the code to delete activity

### DIFF
--- a/qwatson/mainwindow.py
+++ b/qwatson/mainwindow.py
@@ -227,6 +227,7 @@ class QWatsonActivityMixin(object):
         """Setup the widget to show and edit activities."""
         self.overview_widg = ActivityOverviewWidget(self.model)
         self.overview_widg.sig_add_activity.connect(self.add_new_activity)
+        self.overview_widg.sig_del_activity.connect(self.del_activity_at)
         self.overview_widg.sig_load_settings.connect(
             self.set_settings_from_index)
 
@@ -236,11 +237,20 @@ class QWatsonActivityMixin(object):
         stop times.
         """
         self.model.beginInsertRows(QModelIndex(), index, index)
-        self.model.client.insert(
+        self.client.insert(
             index, self.currentProject(), start, stop,
             tags=self.tag_manager.tags, message=self.comment_manager.text())
-        self.model.client.save()
+        self.client.save()
         self.model.endInsertRows()
+
+    def del_activity_at(self, frame_index):
+        """
+        Delete the activity located at the specified index from the database.
+        """
+        self.model.beginRemoveRows(QModelIndex(), frame_index, frame_index)
+        del self.client.frames[frame_index]
+        self.client.save()
+        self.model.endRemoveRows()
 
 
 class QWatson(QWidget, QWatsonImportMixin, QWatsonProjectMixin,

--- a/qwatson/models/delegates.py
+++ b/qwatson/models/delegates.py
@@ -131,7 +131,7 @@ class ToolButtonDelegate(BaseDelegate):
         """Qt method override."""
         if (event.type() == QEvent.MouseButtonPress
                 and event.button() == Qt.LeftButton):
-            model.sig_btn_delrow_clicked.emit(index)
+            model.emit_btn_delrow_clicked(index)
             return True
         else:
             return super(ToolButtonDelegate, self).editorEvent(

--- a/qwatson/models/tablemodels.py
+++ b/qwatson/models/tablemodels.py
@@ -170,13 +170,12 @@ class WatsonTableModel(QAbstractTableModel):
 
     # ---- Watson handlers
 
-    def removeRows(self, index):
-        """Qt method override to remove rows from the model."""
-        self.beginRemoveRows(index.parent(), index.row(), index.row())
-        frame_id = self.client.frames[index.row()].id
-        del self.client.frames[frame_id]
-        self.client.save()
-        self.endRemoveRows()
+    def emit_btn_delrow_clicked(self, index):
+        """
+        Send a signal with the model index where the button to delete an
+        activity has been clicked.
+        """
+        self.sig_btn_delrow_clicked.emit(index)
 
     def editFrame(self, index, start=None, stop=None, project=None,
                   message=None, tags=None):
@@ -203,7 +202,6 @@ class WatsonTableModel(QAbstractTableModel):
 
 
 class WatsonSortFilterProxyModel(QSortFilterProxyModel):
-    sig_btn_delrow_clicked = QSignal(QModelIndex)
     sig_sourcemodel_changed = QSignal()
     sig_total_seconds_changed = QSignal(float)
 
@@ -212,9 +210,6 @@ class WatsonSortFilterProxyModel(QSortFilterProxyModel):
         self.setSourceModel(source_model)
         self.date_span = date_span
         self.total_seconds = None
-
-        self.sig_btn_delrow_clicked.connect(
-            source_model.sig_btn_delrow_clicked.emit)
 
         source_model.dataChanged.connect(self.source_model_changed)
         source_model.rowsInserted.connect(self.source_model_changed)
@@ -299,9 +294,13 @@ class WatsonSortFilterProxyModel(QSortFilterProxyModel):
         return self.sourceModel().get_frameid_from_index(
                    self.mapToSource(proxy_index))
 
-    def removeRows(self, proxy_index):
-        """Map proxy method to source."""
-        self.sourceModel().removeRows(self.mapToSource(proxy_index))
+    def emit_btn_delrow_clicked(self, proxy_index):
+        """
+        Send a signal via the source model with the model index where the
+        button to delete an activity has been clicked.
+        """
+        self.sourceModel().emit_btn_delrow_clicked(
+            self.mapToSource(proxy_index))
 
     def editFrame(self, proxy_index, start=None, stop=None, project=None,
                   message=None, tags=None):

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -140,7 +140,8 @@ class ActivityOverviewWidget(QWidget):
         Send a signal containing the index, the start time, and stop time of
         the new activity that needs to be added to Watson's frames.
         The QWatson mainwindow is in charge of actually adding the activity
-        to Watson's frames.
+        to Watson's frames. The argument 'where' indicates wether the new
+        activity is to be added above or below the selected row.
         """
         index, time = self.table_widg.get_new_activity_index_and_time(where)
         self.sig_add_activity.emit(index, time, time)

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -542,8 +542,9 @@ class FormatedWatsonTableView(BasicWatsonTableView):
         Return the index of the selected row if there is one and return
         None otherwise.
         """
-        if self.is_selected:
-            return self.selectionModel().selectedRows()[0].row()
+        selected_rows = self.selectionModel().selectedRows()
+        if self.is_selected and len(selected_rows) > 0:
+            return selected_rows[0].row()
         else:
             return None
 

--- a/qwatson/widgets/tableviews.py
+++ b/qwatson/widgets/tableviews.py
@@ -38,6 +38,7 @@ from qwatson.models.delegates import (
 class ActivityOverviewWidget(QWidget):
     """A widget to show and edit activities logged with Watson."""
     sig_add_activity = QSignal(int, arrow.Arrow, arrow.Arrow)
+    sig_del_activity = QSignal(int)
     sig_load_settings = QSignal(object)
 
     def __init__(self, model, parent=None):
@@ -46,6 +47,7 @@ class ActivityOverviewWidget(QWidget):
         self.setWindowTitle("Activity Overview")
 
         self.model = model
+        self.model.sig_btn_delrow_clicked.connect(self.del_activity)
 
         self.setup(model)
         self.date_span_changed()
@@ -143,6 +145,25 @@ class ActivityOverviewWidget(QWidget):
         index, time = self.table_widg.get_new_activity_index_and_time(where)
         self.sig_add_activity.emit(index, time, time)
 
+    def del_activity(self, index):
+        """
+        Ask for confirmation to delete a row and delete or not the row from
+        the model according the answer.
+        """
+        frame = self.model.client.frames[index.row()]
+        ans = QMessageBox.question(
+            self, 'Delete frame', "Do you want to delete frame %s?" % frame.id,
+            defaultButton=QMessageBox.No)
+        if ans == QMessageBox.Yes:
+            self.sig_del_activity.emit(index.row())
+
+            # If the activity that was deleted was selected and was the
+            # last activity in the WatsonTableWidget, we need to clear the
+            # focus of the WatsonMultiTableWidget.
+            table = self.table_widg.last_focused_table
+            if table is not None and table.rowCount() == 0:
+                self.table_widg.clear_focused_table()
+
 
 # ---- TableWidget
 
@@ -226,8 +247,6 @@ class WatsonMultiTableWidget(QFrame):
                 self.tables.append(WatsonTableWidget(self.model, parent=self))
                 self.tables[-1].sig_tableview_focused_in.connect(
                     self.tableview_focused_in)
-                self.tables[-1].sig_tableview_cleared.connect(
-                    self.tableview_cleared)
                 self.scene.insertWidget(self.scene.count()-1, self.tables[-1])
             else:
                 self.tables.remove(self.tables[-1])
@@ -262,14 +281,6 @@ class WatsonMultiTableWidget(QFrame):
             self.clear_focused_table()
             table.view.set_selected(True)
             self.last_focused_table = table
-
-    def tableview_cleared(self, table):
-        """
-        Handle when one of the tables is now empty due to the user deleting
-        one or more of its activities.
-        """
-        if table == self.last_focused_table:
-            self.clear_focused_table()
 
     def clear_focused_table(self):
         """Clear the last focused table."""
@@ -357,8 +368,6 @@ class WatsonTableWidget(QWidget):
             self.setup_timecount)
         self.view.sig_focused_in.connect(
             lambda: self.sig_tableview_focused_in.emit(self))
-        self.view.sig_table_cleared.connect(
-            lambda: self.sig_tableview_cleared.emit(self))
 
     def setup_titlebar(self):
         """Setup the titlebar of the table."""
@@ -422,7 +431,6 @@ class BasicWatsonTableView(QTableView):
     A single table view that displays Watson activity log and
     allow sorting and filtering of the data through the use of a proxy model.
     """
-    sig_table_cleared = QSignal(object)
 
     def __init__(self, source_model, parent=None):
         super(BasicWatsonTableView, self).__init__(parent)
@@ -430,7 +438,6 @@ class BasicWatsonTableView(QTableView):
 
         self.proxy_model = WatsonSortFilterProxyModel(source_model)
         self.setModel(self.proxy_model)
-        self.proxy_model.sig_btn_delrow_clicked.connect(self.del_model_row)
 
         # ---- Setup the delegates
 
@@ -456,20 +463,6 @@ class BasicWatsonTableView(QTableView):
         self.horizontalHeader().setSectionResizeMode(QHeaderView.Fixed)
         self.horizontalHeader().setSectionResizeMode(
             columns['comment'], QHeaderView.Stretch)
-
-    def del_model_row(self, proxy_index):
-        """
-        Ask for confirmation to delete a row and delete or not the row from
-        the model according the answer.
-        """
-        frame_id = self.proxy_model.get_frameid_from_index(proxy_index)
-        ans = QMessageBox.question(
-            self, 'Delete frame', "Do you want to delete frame %s?" % frame_id,
-            defaultButton=QMessageBox.No)
-        if ans == QMessageBox.Yes:
-            self.proxy_model.removeRows(proxy_index)
-            if self.proxy_model.get_accepted_row_count() == 0:
-                self.sig_table_cleared.emit(self)
 
     def set_date_span(self, date_span):
         """Set the date span in the proxy model."""


### PR DESCRIPTION
The goal of this PR is to make the main widget of QWatson actually responsible to delete the activities from the database. 

This will make the code easier to understand and to maintain and will allow eventually to add a button in the activity overview to delete activity from the toolbar and to make the delete dialog a QWatson dialog instead of an independent popup. This was not possible before this PR because the code to do this was to deep in the lower layers of the code structure.